### PR TITLE
Fix for issue #8

### DIFF
--- a/plone/app/event/at/content.py
+++ b/plone/app/event/at/content.py
@@ -25,6 +25,7 @@ from plone.app.event.interfaces import IEvent
 from plone.app.event.interfaces import IRecurrence
 from plone.app.event.interfaces import IEventAccessor
 from plone.app.event.base import default_end_DT
+from plone.app.event.base import default_start_DT
 from plone.app.event.base import default_timezone
 from plone.event.recurrence import recurrence_sequence_ical
 from plone.event.utils import pydt
@@ -37,7 +38,7 @@ ATEventSchema = ATContentTypeSchema.copy() + atapi.Schema((
         searchable=False,
         accessor='start',
         write_permission=ModifyPortalContent,
-        default_method=DateTime,
+        default_method=default_start_DT,
         languageIndependent=True,
         widget=DatetimeWidget(
             label=_(u'label_event_start', default=u'Event Starts'),

--- a/plone/app/event/base.py
+++ b/plone/app/event/base.py
@@ -17,6 +17,7 @@ from plone.app.event.interfaces import IRecurrence
 
 DEFAULT_END_DELTA = 1 # hours
 
+
 def default_end_dt():
     """ Return the default end as python datetime for prefilling forms.
 
@@ -47,6 +48,13 @@ def default_end_DT():
     ...            DTE.minute() == DTN.minute())
     """
     return DT(default_end_dt())
+
+
+def default_start_DT():
+    """ Return the default start as a Zope DateTime for prefilling
+        archetypes forms.
+    """
+    return DT(localized_now())
 
 
 def default_timezone(context=None):

--- a/plone/app/event/tests/test_atevent.py
+++ b/plone/app/event/tests/test_atevent.py
@@ -104,6 +104,9 @@ class PAEventATTest(unittest.TestCase):
         self.assertEqual(new.end_date, pydt(OBJ_DATA['endDate']))
         self.assertEqual(new.duration, new.end_date - new.start_date)
 
+    def test_sane_start_end(self):
+        self.assertTrue(self.obj.start() <= self.obj.end())
+
     def test_cmp(self):
         portal = self.portal
         e1 = self.obj


### PR DESCRIPTION
This commit makes the default start date of the ATEvent timezone aware.
Otherwise an issue arises if the end date creates a timezone aware datetime which lies behind the start date. This fixes reported issue #8.
