### PR TITLE
Don't use Annotation storage for DX behaviors

### DIFF
--- a/plone/app/event/dx/behaviors.py
+++ b/plone/app/event/dx/behaviors.py
@@ -19,6 +19,7 @@ from plone.app.textfield import RichText
 from plone.app.textfield.value import RichTextValue
 from plone.autoform import directives as form
 from plone.autoform.interfaces import IFormFieldProvider
+from plone.dexterity.interfaces import IDexterityContent
 from plone.event.interfaces import IEventAccessor
 from plone.event.utils import tzdel, utc, dt_to_zone
 from plone.formwidget.datetime.z3cform.widget import DatetimeFieldWidget
@@ -278,6 +279,14 @@ class IEventSummary(model.Schema):
         ),
         required=False,
     )
+
+
+class EventSummary(object):
+    implements(IEventSummary)
+    adapts(IDexterityContent)
+
+    def __init__(self, context):
+        self.context = context
 
 
 # Mark these interfaces as form field providers

--- a/plone/app/event/dx/configure.zcml
+++ b/plone/app/event/dx/configure.zcml
@@ -81,7 +81,8 @@
         title="Event Summary"
         description="Summary/body text extension for Events."
         provides=".behaviors.IEventSummary"
-        factory="plone.behavior.AnnotationStorage"
+        factory=".behaviors.EventSummary"
+        marker=".behaviors.IEventSummary"
         for="plone.dexterity.interfaces.IDexterityContent"
         />
 


### PR DESCRIPTION
(was: access text using obj.text)
- provide upgrade steps for it
