### PR TITLE
fix: use context for formatted date in event_view

### DIFF
--- a/plone/app/event/browser/event_view.py
+++ b/plone/app/event/browser/event_view.py
@@ -42,7 +42,7 @@ class EventView(BrowserView):
             (self.context, self.request, self),
             IContentProvider, name='formatted_date'
         )
-        return provider(occ)
+        return provider(occ.context)
 
     @property
     def next_occurrences(self):


### PR DESCRIPTION
Using context allows the localization of the date.

It's already the case in event_listing: https://github.com/plone/plone.app.event/blob/master/plone/app/event/browser/event_listing.py#L200
