### PR TITLE
Remove data_postprocessing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Changelog
 2.0.0 (unreleased)
 ------------------
 
+- Remove ``data_postprocessing`` logic, which was handling ``open_end`` and
+  ``whole_day`` events and was manipulating the object on form submission.
+  Instead, just adapt start/end dates on indexing and when accessing them via
+  ``IEventAccessor``.
+  [thet]
+
 - No need to return DateTime objects for the indexer.
   Products.DateRecurringIndex works with Python datetime objects.
   [thet]

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -136,35 +136,11 @@ tzinfo object directly on the datetime object like `datetime(2010, 10, 10, 12,
 your timezone!
 
 
-2) If you set `whole_day` or `open_end`, wether set the start and end times
-accordingly or use the provided `data_postprocessing` or
-`data_postprocessing_context` conveininence functions.
-
-Setting a `whole_day` event::
-
-    event.start = tz.localize(datetime(2010, 10, 10, 0, 0, 0))
-    event.end = tz.localize(datetime(2010, 10, 10, 23, 59, 59))
-    event.whole_day = True
-
-Setting a `open_end` event::
-
-    event.start = tz.localize(datetime(2010, 10, 10, 12, 12))
-    event.end = tz.localize(datetime(2010, 10, 10, 23, 59, 59))
-    event.open_day = True
-
-Using `data_postprocessing`::
-
-    event.start, event.end, event.whole_day, event.open_end =\
-        data_postprocessing(
-            event.start, event.end, event.whole_day, event.open_end)
-
-Using `data_postprocessing_context`::
-
-    data_postprocessing_context(context)
-
-
-If you set the values through a z3c.form, an event handler listening to
-`z3c.form.events.DataExtractedEvent` will take care of this.
+2) Since plone.app.event 2.0b1, there is no need to call the
+``data_postprocessing`` function to manipulate the object accordingly to the
+value of the ``whole_day`` or ``end_date`` attributes. The start and end dates
+are only converted to the beginning respectively to the end of the day for
+indexing and when accessing the dates via the IEventAccessor.
 
 
 Accessing event objects via an unified accessor object

--- a/plone/app/event/dx/configure.zcml
+++ b/plone/app/event/dx/configure.zcml
@@ -31,9 +31,6 @@
     <adapter name="SearchableText" factory=".behaviors.searchable_text_indexer" />
     <adapter name="sync_uid" factory=".behaviors.sync_uid_indexer" />
 
-    <subscriber for="z3c.form.interfaces.IDataExtractedEvent"
-                handler=".behaviors.data_postprocessing_handler" />
-
     <plone:behavior
         title="Event Basic"
         description="Basic Event schema."

--- a/plone/app/event/tests/base_setup.py
+++ b/plone/app/event/tests/base_setup.py
@@ -2,7 +2,6 @@ from Products.CMFCore.utils import getToolByName
 from datetime import datetime
 from datetime import timedelta
 from plone.app.event.dx import behaviors
-from plone.app.event.dx.behaviors import data_postprocessing_context
 from plone.app.event.testing import set_browserlayer
 from plone.app.event.testing import set_timezone
 from plone.app.testing import TEST_USER_ID
@@ -76,7 +75,6 @@ class AbstractSampleDataEvents(unittest.TestCase):
             recurrence='RRULE:FREQ=DAILY;COUNT=3')
         workflow.doActionFor(self.past_event, 'publish')
         # adjust start and end according to whole_day and open_end
-        data_postprocessing_context(self.past_event)
         self.past_event.reindexObject()
 
         self.now_event = factory(
@@ -98,7 +96,6 @@ EXDATE:20130506T000000,20140404T000000""",
         # https://github.com/plone/plone.dexterity/pull/18
         # https://github.com/plone/plone.app.dexterity/issues/118
         workflow.doActionFor(self.now_event, 'publish')
-        data_postprocessing_context(self.now_event)
         self.now_event.reindexObject()
 
         self.future_event = factory(
@@ -109,7 +106,6 @@ EXDATE:20130506T000000,20140404T000000""",
             end=future + duration,
             location=u'Graz')
         workflow.doActionFor(self.future_event, 'publish')
-        data_postprocessing_context(self.future_event)
         self.future_event.reindexObject()
 
         self.portal.invokeFactory('Folder', 'sub', title=u'sub')
@@ -121,7 +117,6 @@ EXDATE:20130506T000000,20140404T000000""",
             end=far,
             location=u'Schaftal')
         workflow.doActionFor(self.long_event, 'publish')
-        data_postprocessing_context(self.long_event)
         self.long_event.reindexObject()
 
         # For AT based tests, this is a plone.app.collection ICollection type

--- a/plone/app/event/tests/test_base_module.py
+++ b/plone/app/event/tests/test_base_module.py
@@ -19,7 +19,6 @@ from plone.app.event.base import find_ploneroot
 from plone.app.event.base import find_site
 from plone.app.event.base import get_events
 from plone.app.event.base import localized_now
-from plone.app.event.dx.behaviors import data_postprocessing_context
 from plone.app.event.testing import PAEventDX_INTEGRATION_TESTING
 from plone.app.event.testing import PAEvent_INTEGRATION_TESTING
 from plone.app.event.testing import set_env_timezone
@@ -556,8 +555,6 @@ class TestGetEventsDX(AbstractSampleDataEvents):
             location=u"Dornbirn",
             recurrence='RRULE:FREQ=WEEKLY;COUNT=4',
         )
-        # data_postprocessing normalization is not needed, as we values are set
-        # correctly in the first place.
 
         tomorrow = factory(
             container=self.portal,
@@ -568,9 +565,6 @@ class TestGetEventsDX(AbstractSampleDataEvents):
             open_end=True,
             location=u"Dornbirn",
         )
-        # Normalize values and reindex, what normally the form would do
-        # (especially, end time isn't set like open_end settings requests to.
-        data_postprocessing_context(tomorrow)
         tomorrow.reindexObject()
 
         limit = get_events(self.portal, start=self.now, expand=True,
@@ -655,8 +649,6 @@ class TestGetEventsOptimizations(AbstractSampleDataEvents):
             location=u"Dornbirn",
             recurrence='RRULE:FREQ=WEEKLY;COUNT=4',
         )
-        # data_postprocessing normalization is not needed, as we values are set
-        # correctly in the first place.
 
         tomorrow = factory(
             container=self.portal,
@@ -667,9 +659,6 @@ class TestGetEventsOptimizations(AbstractSampleDataEvents):
             open_end=True,
             location=u"Dornbirn",
         )
-        # Normalize values and reindex, what normally the form would do
-        # (especially, end time isn't set like open_end settings requests to.
-        data_postprocessing_context(tomorrow)
         tomorrow.reindexObject()
 
         self.occ = [

--- a/plone/app/event/tests/test_dx_behaviors.py
+++ b/plone/app/event/tests/test_dx_behaviors.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from DateTime import DateTime
 from OFS.SimpleItem import SimpleItem
 from datetime import datetime, timedelta
 from plone.app.event import base
@@ -8,7 +7,6 @@ from plone.app.event.base import localized_now
 from plone.app.event.dx.behaviors import IEventBasic
 from plone.app.event.dx.behaviors import IEventRecurrence
 from plone.app.event.dx.behaviors import StartBeforeEnd
-from plone.app.event.dx.behaviors import data_postprocessing_context
 from plone.app.event.dx.behaviors import default_end
 from plone.app.event.dx.behaviors import default_start
 from plone.app.event.dx.interfaces import IDXEvent
@@ -221,7 +219,7 @@ class TestDXAddEdit(unittest.TestCase):
         self.assertTrue('23:59' in self.browser.contents)
 
 
-class TestDataPostprocessing(unittest.TestCase):
+class TestEventAccessor(unittest.TestCase):
     layer = PAEventDX_INTEGRATION_TESTING
 
     def setUp(self):
@@ -230,7 +228,28 @@ class TestDataPostprocessing(unittest.TestCase):
         set_browserlayer(self.request)
         setRoles(self.portal, TEST_USER_ID, ['Manager'])
 
-    def test_data_postprocessing(self):
+    def test_event_accessor(self):
+        tz = pytz.timezone("Europe/Vienna")
+        e1 = createContentInContainer(
+            self.portal,
+            'plone.app.event.dx.event',
+            title='event1',
+            start=tz.localize(datetime(2011, 11, 11, 11, 0)),
+            end=tz.localize(datetime(2011, 11, 11, 12, 0)),
+        )
+
+        # setting attributes via the accessor
+        acc = IEventAccessor(e1)
+        new_end = tz.localize(datetime(2011, 11, 13, 10, 0))
+        acc.end = new_end
+
+        # context's end should be set to new_end
+        self.assertEqual(e1.end, new_end)
+
+        # accessor's and context datetime should be the same
+        self.assertEqual(acc.end, e1.end)
+
+    def test_event_accessor_whole_day__open_end(self):
 
         at = pytz.timezone("Europe/Vienna")
 
@@ -247,25 +266,25 @@ class TestDataPostprocessing(unittest.TestCase):
             start=start,
             end=end
         )
+        acc = IEventAccessor(e1)
 
-        # See, if start isn't moved by timezone offset. Addressing issue #62
-        self.assertEqual(e1.start, start)
-        self.assertEqual(e1.end, end)
-        data_postprocessing_context(e1)
+        # check set
         self.assertEqual(e1.start, start)
         self.assertEqual(e1.end, end)
 
         # Setting open end
         e1.open_end = True
-        data_postprocessing_context(e1)
         self.assertEqual(e1.start, start)
-        self.assertEqual(e1.end, end_end)
+        self.assertEqual(e1.end, end)
+        self.assertEqual(acc.start, start)
+        self.assertEqual(acc.end, end_end)
 
         # Setting whole day
         e1.whole_day = True
-        data_postprocessing_context(e1)
-        self.assertEqual(e1.start, start_start)
-        self.assertEqual(e1.end, end_end)
+        self.assertEqual(e1.start, start)
+        self.assertEqual(e1.end, end)
+        self.assertEqual(acc.start, start_start)
+        self.assertEqual(acc.end, end_end)
 
 
 class TestDXIntegration(unittest.TestCase):
@@ -343,27 +362,6 @@ class TestDXIntegration(unittest.TestCase):
             expand=True
         )
         self.assertEqual(len(result), 4)
-
-    def test_event_accessor(self):
-        tz = pytz.timezone("Europe/Vienna")
-        e1 = createContentInContainer(
-            self.portal,
-            'plone.app.event.dx.event',
-            title='event1',
-            start=tz.localize(datetime(2011, 11, 11, 11, 0)),
-            end=tz.localize(datetime(2011, 11, 11, 12, 0)),
-        )
-
-        # setting attributes via the accessor
-        acc = IEventAccessor(e1)
-        new_end = tz.localize(datetime(2011, 11, 13, 10, 0))
-        acc.end = new_end
-
-        # context's end should be set to new_end
-        self.assertEqual(e1.end, new_end)
-
-        # accessor's and context datetime should be the same
-        self.assertEqual(acc.end, e1.end)
 
 
 class TestDXEventRecurrence(unittest.TestCase):


### PR DESCRIPTION
Remove ``data_postprocessing`` logic, which was handling ``open_end`` and
``whole_day`` events and was manipulating the object on form submission.
Instead, just adapt start/end dates on indexing and when accessing them via
``IEventAccessor``.

RFC: @jensens @regebro @zopyx @davisagli 

should be safe and backwards-compatible, except that people will have to stop using data_postprocessing, if they do.