### PR TITLE
CSS class for the timezone in portlet_events.pt

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,9 @@ Changelog
   Collection's query.
   [thet]
 
+- Add a CSS class for the timezone in the events portlet.
+  [mitakas]
+
 
 2.0a7 (2015-03-13)
 ------------------

--- a/plone/app/event/bbb/portlets/portlet_events.pt
+++ b/plone/app/event/bbb/portlets/portlet_events.pt
@@ -31,7 +31,11 @@
         </a>
         <span class="portletItemDetails">
             <tal:date replace="structure python:view.formatted_date(item)" />
-            <span tal:define="tz item/timezone" tal:condition="tz">(<tal:tzname replace="tz">TZ</tal:tzname>)</span>
+            <span class="timezone"
+                tal:define="tz item/timezone"
+                tal:condition="tz">
+                (<tal:tzname replace="tz">TZ</tal:tzname>)
+            </span>
             <span class="location"
                 tal:define="location python:view.get_location(item)"
                 tal:condition="location"> &mdash;

--- a/plone/app/event/portlets/portlet_events.pt
+++ b/plone/app/event/portlets/portlet_events.pt
@@ -27,7 +27,11 @@
         </a>
         <span class="portletItemDetails">
           <tal:date replace="structure python:view.formatted_date(item)" />
-          <span tal:define="tz item/timezone" tal:condition="tz">(<tal:tzname replace="tz">TZ</tal:tzname>)</span>
+          <span class="timezone"
+              tal:define="tz item/timezone"
+              tal:condition="tz">
+            (<tal:tzname replace="tz">TZ</tal:tzname>)
+          </span>
           <span class="location"
               tal:define="location python:view.get_location(item)"
               tal:condition="location"> &mdash;


### PR DESCRIPTION
Location already has a CSS class and sometimes hiding the timezone makes the list of events neater.