### PR TITLE
remove get_location view helper

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,13 @@ Changelog
 2.0a8 (unreleased)
 ------------------
 
+- Remove ``get_location`` view helper method. This was used to allow external
+  addons (specifically ``collective.venue``) to override it and return a html
+  link to a location object instead. Instead of this hack, which also only
+  works for the location use case, override the necessary templates in your
+  addons. In case of doubt, simplicity outweight extensibility options.
+  [thet]
+
 - Change ``adapts`` and ``implements`` to their decorator equivalents
   ``adapter`` and ``implementer``.
   [thet]

--- a/plone/app/event/bbb/portlets/portlet_events.pt
+++ b/plone/app/event/bbb/portlets/portlet_events.pt
@@ -37,9 +37,8 @@
                 (<tal:tzname replace="tz">TZ</tal:tzname>)
             </span>
             <span class="location"
-                tal:define="location python:view.get_location(item)"
-                tal:condition="location"> &mdash;
-                <tal:location content="structure location">Location</tal:location>
+                tal:condition="item/location"> &mdash;
+                <tal:location content="structure item/location">Location</tal:location>
             </span>
         </span>
     </dd>

--- a/plone/app/event/browser/event_listing.pt
+++ b/plone/app/event/browser/event_listing.pt
@@ -101,9 +101,8 @@
           <div class="documentByLine">
             <tal:date tal:replace="structure python:view.formatted_date(data)"/>
             <div itemprop="location" class="location"
-                tal:define="location python:view.get_location(data)"
-                tal:condition="location"
-                tal:content="structure location">location</div>
+                tal:condition="data/location"
+                tal:content="structure data/location">location</div>
           </div>
 
           <p itemprop="description" class="description" tal:condition="data/description" tal:content="data/description" />

--- a/plone/app/event/browser/event_listing.py
+++ b/plone/app/event/browser/event_listing.py
@@ -14,7 +14,6 @@ from plone.app.event.base import guess_date_from
 from plone.app.event.base import localized_now
 from plone.app.event.base import start_end_from_mode
 from plone.app.event.base import start_end_query
-from plone.app.event.browser.event_view import get_location
 from plone.app.event.ical.exporter import construct_icalendar
 from plone.app.layout.navigation.defaultpage import getDefaultPage
 from plone.app.querystring import queryparser
@@ -225,9 +224,6 @@ class EventListing(BrowserView):
             if r == "min":
                 se["start"] = q
         return se["start"], se["end"]
-
-    def get_location(self, occ):
-        return get_location(occ)
 
     def formatted_date(self, occ):
         provider = getMultiAdapter(

--- a/plone/app/event/browser/event_summary.pt
+++ b/plone/app/event/browser/event_summary.pt
@@ -67,10 +67,10 @@
     </tal:cond>
 
     <tal:cond condition="python:'location' not in excludes">
-    <tal:cond define="location view/get_location" condition="location">
+    <tal:cond condition="data/location">
       <li class="event-location">
         <strong i18n:translate="event_where">Where</strong>
-        <span itemprop="location" tal:content="structure location">Location</span>
+        <span itemprop="location" tal:content="structure data/location">Location</span>
       </li>
     </tal:cond>
     </tal:cond>

--- a/plone/app/event/browser/event_summary.py
+++ b/plone/app/event/browser/event_summary.py
@@ -7,7 +7,6 @@ from plone.event.interfaces import IRecurrenceSupport
 from plone.uuid.interfaces import IUUID
 from zope.component import getMultiAdapter
 from zope.contentprovider.interfaces import IContentProvider
-from plone.app.event.browser.event_view import get_location
 
 
 class EventSummaryView(BrowserView):
@@ -18,10 +17,6 @@ class EventSummaryView(BrowserView):
         self.data = IEventAccessor(context)
         self.max_occurrences = 6
         self.excludes = ['title', ]
-
-    @property
-    def get_location(self):
-        return get_location(self.context)
 
     @property
     def is_occurrence(self):

--- a/plone/app/event/browser/event_view.py
+++ b/plone/app/event/browser/event_view.py
@@ -3,23 +3,6 @@ from plone.event.interfaces import IEventAccessor
 from plone.event.interfaces import IOccurrence
 
 
-def get_location(accessor):
-    """Return the location.
-    This method can be overwritten by external packages, for example to provide
-    a reference to a Location object as done by collective.venue.
-
-    :param accessor: Event, Occurrence or IEventAccessor object.
-    :type accessor: IEvent, IOccurrence or IEventAccessor
-
-    :returns: A location string. Possibly a HTML structure to link to another
-              object, representing the location.
-    :rtype: string
-    """
-    if not IEventAccessor.providedBy(accessor):
-        accessor = IEventAccessor(accessor)
-    return accessor.location
-
-
 class EventView(BrowserView):
 
     def __init__(self, context, request):

--- a/plone/app/event/ical/importer.py
+++ b/plone/app/event/ical/importer.py
@@ -203,12 +203,6 @@ def ical_import(container, ics_resource, event_type,
             event.sync_uid = sync_uid
         notify(ObjectModifiedEvent(content))
 
-        # Archetypes specific code
-        if getattr(content, 'processForm', False):
-            # Will finish Archetypes content item creation process,
-            # rename-after-creation and such
-            content.processForm()
-
         # Use commits instead of savepoints to avoid "FileStorageError:
         # description too long" on large imports.
         transaction.get().commit()  # Commit before rename

--- a/plone/app/event/portlets/portlet_events.pt
+++ b/plone/app/event/portlets/portlet_events.pt
@@ -33,9 +33,8 @@
             (<tal:tzname replace="tz">TZ</tal:tzname>)
           </span>
           <span class="location"
-              tal:define="location python:view.get_location(item)"
-              tal:condition="location"> &mdash;
-            <tal:location content="structure location">Location</tal:location>
+              tal:condition="item/location"> &mdash;
+            <tal:location content="structure item/location">Location</tal:location>
           </span>
         </span>
       </li>

--- a/plone/app/event/portlets/portlet_events.py
+++ b/plone/app/event/portlets/portlet_events.py
@@ -4,7 +4,6 @@ from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from plone.app.event.base import RET_MODE_ACCESSORS
 from plone.app.event.base import get_events
 from plone.app.event.base import localized_now
-from plone.app.event.browser.event_view import get_location
 from plone.app.event.portlets import get_calendar_url
 from plone.app.portlets import PloneMessageFactory as _
 from plone.app.portlets.portlets import base
@@ -139,9 +138,6 @@ class Renderer(base.Renderer):
             IContentProvider, name='formatted_date'
         )
         return provider(event)
-
-    def get_location(self, event):
-        return get_location(event)
 
 
 class AddForm(base.AddForm):

--- a/plone/app/event/tests/test_event_summary.py
+++ b/plone/app/event/tests/test_event_summary.py
@@ -33,13 +33,12 @@ class TestEventSummaryDX(AbstractSampleDataEvents):
         view = self.portal.now.restrictedTraverse('@@event_summary')
 
         self.assertEqual(view.is_occurrence, False)
-        self.assertEqual(view.get_location, u'Vienna')
         self.assertEqual(len(view.next_occurrences), 3)
         self.assertEqual(view.num_more_occurrences, 0)
 
         output = view()
 
-        #self.assertTrue('Now Event' not in output)  # Title not shown by def.
+        # self.assertTrue('Now Event' not in output)  # Title not shown by def.
         self.assertTrue('2013-05-05' in output)
         self.assertTrue('All dates' in output)
         self.assertTrue('2013-05-07' in output)
@@ -54,7 +53,6 @@ class TestEventSummaryDX(AbstractSampleDataEvents):
         view = occ.restrictedTraverse('@@event_summary')
 
         self.assertEqual(view.is_occurrence, True)
-        self.assertEqual(view.get_location, u'Vienna')
         self.assertEqual(len(view.next_occurrences), 3)
         self.assertEqual(view.num_more_occurrences, 0)
 


### PR DESCRIPTION
Remove ``get_location`` view helper method. This was used to allow external addons (specifically ``collective.venue``) to override it and return a html link to a location object instead. Instead of this hack, which also only works for the location use case, override the necessary templates in your addons. In case of doubt, simplicity outweight extensibility options.