### PR TITLE
ImageScalingViewFactory and ILeadImage viewlet customization for Occurrences

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 2.0a9 (unreleased)
 ------------------
 
+- Fix ``ImageScalingViewFactory`` and add a custom ILeadImage viewlet for
+  Occurrences. Fixes the display of ILeadImage images from the originating
+  event in event views of occurrences by delegating to the parent object.
+  [thet]
+
 - Fix Plone 4.3 BBB z3c.form portlets to show their fields in Add/Edit Forms.
   [thet]
 

--- a/plone/app/event/browser/configure.zcml
+++ b/plone/app/event/browser/configure.zcml
@@ -1,6 +1,7 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:browser="http://namespaces.zope.org/browser"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="plone.app.event">
 
     <browser:resourceDirectory
@@ -77,6 +78,19 @@
         permission="zope2.View"
         layer="..interfaces.IBrowserLayer"
         />
+
+    <configure
+        zcml:condition="installed plone.app.contenttypes"
+        package="plone.app.contenttypes.behaviors">
+      <browser:viewlet
+          name="contentleadimage"
+          for="plone.event.interfaces.IOccurrence"
+          class="plone.app.event.browser.leadimage_viewlet.LeadImageViewlet"
+          manager="plone.app.layout.viewlets.interfaces.IAboveContentTitle"
+          template="leadimage.pt"
+          permission="zope2.View"
+          />
+    </configure>
 
     <adapter
         name="formatted_date"

--- a/plone/app/event/browser/leadimage_viewlet.py
+++ b/plone/app/event/browser/leadimage_viewlet.py
@@ -1,0 +1,13 @@
+from Acquisition import aq_parent
+from plone.app.contenttypes.behaviors.leadimage import ILeadImage
+from plone.app.layout.viewlets import ViewletBase
+
+
+class LeadImageViewlet(ViewletBase):
+    """plone.app.contenttypes LeadImageViewlet for Occurrence contexts, where
+    the image might be defined on the parent object.
+    """
+    def update(self):
+        parent = aq_parent(self.context)
+        self.available = ILeadImage.providedBy(parent) and\
+            True if getattr(parent, 'image', False) else False

--- a/plone/app/event/recurrence.py
+++ b/plone/app/event/recurrence.py
@@ -9,9 +9,9 @@ from plone.event.interfaces import IOccurrence
 from plone.event.interfaces import IRecurrenceSupport
 from plone.event.recurrence import recurrence_sequence_ical
 from plone.event.utils import is_same_day
-from plone.namedfile.scaling import ImageScale as DXImageScaling
+from plone.namedfile.interfaces import IImageScaleTraversable
+from plone.namedfile.scaling import ImageScaling
 from zope.component import adapter
-from zope.interface import Interface
 from zope.interface import implementer
 from zope.publisher.interfaces.browser import IBrowserRequest
 
@@ -19,22 +19,6 @@ try:
     from repoze.zope2.publishtraverse import DefaultPublishTraverse
 except ImportError:
     from ZPublisher.BaseRequest import DefaultPublishTraverse
-
-try:
-    from plone.app.event.at.interfaces import IATEvent
-except ImportError:
-    class IATEvent(Interface):
-        pass
-try:
-    from plone.app.event.dx.interfaces import IDXEvent
-except ImportError:
-    class IDXEvent(Interface):
-        pass
-
-try:
-    from plone.app.imaging.scaling import ImageScaling as ATImageScaling
-except ImportError:
-    pass
 
 
 @adapter(IEventRecurrence)
@@ -174,13 +158,11 @@ class EventOccurrenceAccessor(object):
 
 
 class ImageScalingViewFactory(BrowserView):
-    """Factory for ImageScaling view for occurrences.
-    Delegates to AT or DX specific view and rebinds to the parent context.
+    """Factory for ImageScaling view for Occurrences.
+    Delegates to parent @@images view.
     """
     def __new__(cls, context, request):
         parent = aq_parent(context)
-        if IATEvent.providedBy(parent):
-            return ATImageScaling(parent, request)
-        elif IDXEvent.providedBy(parent):
-            return DXImageScaling(parent, request)
+        if IImageScaleTraversable.providedBy(parent):
+            return ImageScaling(parent, request)
         return None


### PR DESCRIPTION
- Fix ``ImageScalingViewFactory`` and add a custom ILeadImage viewlet for Occurrences. Fixes the display of ILeadImage images from the originating event in event views of occurrences by delegating to the parent object.

- Fix Plone 4.3 BBB z3c.form portlets to show their fields in Add/Edit Forms.