### PR TITLE
Support for contentFilter on request for event_listing.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 2.0a9 (unreleased)
 ------------------
 
+- Support for ``contentFilter`` on request for ``event_listing``.
+  [thet]
+
 - Fix ``ImageScalingViewFactory`` and add a custom ILeadImage viewlet for
   Occurrences. Fixes the display of ILeadImage images from the originating
   event in event views of occurrences by delegating to the parent object.

--- a/plone/app/event/browser/event_listing.py
+++ b/plone/app/event/browser/event_listing.py
@@ -139,12 +139,12 @@ class EventListing(BrowserView):
         if self.is_collection:
             ctx = self.default_context
             query = queryparser.parseFormquery(ctx, ctx.query)
-            custom_query = {}
+            custom_query = self.request.get('contentFilter', {})
             if 'start' not in query or 'end' not in query:
                 # ... else don't show the navigation bar
                 start, end = self._start_end
                 start, end = _prepare_range(ctx, start, end)
-                custom_query = start_end_query(start, end)
+                custom_query.update(start_end_query(start, end))
             res = ctx.results(
                 batch=False, brains=True, custom_query=custom_query
             )


### PR DESCRIPTION
This allows the contentFilter dictionary on a request to narrow down listings