### PR TITLE
Point to documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,3 +7,5 @@ Recurrence support, event views and a lot more.
 
 For a Dexterity event type using plone.app.event, use plone.app.contenttypes
 1.1 or newer.
+
+The complete documentation can be found on: https://ploneappevent.readthedocs.org


### PR DESCRIPTION
Fixes https://github.com/plone/plone.app.event/issues/179

@svx do we host that documentation somewhere on docs.plone.org? Should I open a ticket for it? @thet any reason not to move the docs to docs.plone.org?