### PR TITLE
more collection improvements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ Changelog
 2.0a9 (2015-05-04)
 ------------------
 
+- For ``event_listing`` on Collections, ignore the Collection's sorting and use
+  what the event listing's mode defines for sorting.
+  [thet]
+
 - Add support for Collections as data source for calendar and event portlets.
   [thet]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ Changelog
 2.0a9 (2015-05-04)
 ------------------
 
+- Add support for Collections as data source for calendar and event portlets.
+  [thet]
+
 - Extend Collection support on ``event_listing`` for content items providing
   ``ISyndicatableCollection``.
   [thet]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,12 +4,6 @@ Changelog
 2.0a10 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
-
-2.0a9 (2015-05-04)
-------------------
-
 - For ``event_listing`` on Collections, ignore the Collection's sorting and use
   what the event listing's mode defines for sorting.
   [thet]
@@ -20,6 +14,10 @@ Changelog
 - Extend Collection support on ``event_listing`` for content items providing
   ``ISyndicatableCollection``.
   [thet]
+
+
+2.0a9 (2015-05-04)
+------------------
 
 - Support for ``contentFilter`` on request for ``event_listing``.
   [thet]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ Changelog
 2.0a9 (2015-05-04)
 ------------------
 
+- Extend Collection support on ``event_listing`` for content items providing
+  ``ISyndicatableCollection``.
+  [thet]
+
 - Support for ``contentFilter`` on request for ``event_listing``.
   [thet]
 

--- a/plone/app/event/browser/event_listing.py
+++ b/plone/app/event/browser/event_listing.py
@@ -138,7 +138,14 @@ class EventListing(BrowserView):
         res = []
         if self.is_collection:
             ctx = self.default_context
-            query = queryparser.parseFormquery(ctx, ctx.query)
+            # Whatever sorting is defined, we're overriding it.
+            sort_on = 'start'
+            sort_order = None
+            if self.mode in ('past', 'all'):
+                sort_order = 'reverse'
+            query = queryparser.parseFormquery(
+                ctx, ctx.query, sort_on=sort_on, sort_order=sort_order
+            )
             custom_query = self.request.get('contentFilter', {})
             if 'start' not in query or 'end' not in query:
                 # ... else don't show the navigation bar
@@ -156,7 +163,9 @@ class EventListing(BrowserView):
                     query.get('end') or custom_query.get('end')
                 )
                 res = expand_events(
-                    res, ret_mode, sort='start', start=start, end=end
+                    res, ret_mode,
+                    start=start, end=end,
+                    sort=sort_on, sort_reverse=True if sort_order else False
                 )
         else:
             res = self._get_events(ret_mode, expand=expand)

--- a/plone/app/event/browser/event_listing.py
+++ b/plone/app/event/browser/event_listing.py
@@ -23,7 +23,7 @@ from zope.component import getMultiAdapter
 from zope.contentprovider.interfaces import IContentProvider
 
 try:
-    from plone.app.contenttypes.interfaces import ICollection
+    from plone.app.contenttypes.behaviors.collection import ISyndicatableCollection as ICollection  # noqa
 except ImportError:
     ICollection = None
 

--- a/plone/app/event/portlets/portlet_events.py
+++ b/plone/app/event/portlets/portlet_events.py
@@ -172,12 +172,14 @@ class Renderer(base.Renderer):
             start, end = _prepare_range(search_base, start, end)
             query_kw.update(start_end_query(start, end))
             events = search_base.results(
-                batch=False, brains=True, custom_query=query_kw
+                batch=False, brains=True, custom_query=query_kw,
+                limit=data.count
             )
             events = expand_events(
                 events, ret_mode=RET_MODE_ACCESSORS,
                 sort='start', start=start, end=end
             )
+            events = events[:data.count]  # limit expanded
         else:
             search_base_path = self.search_base_path
             if search_base_path:

--- a/plone/app/event/portlets/portlet_events.py
+++ b/plone/app/event/portlets/portlet_events.py
@@ -149,15 +149,19 @@ class Renderer(base.Renderer):
         context = aq_inner(self.context)
         data = self.data
 
-        query_kw = {}
+        query = {}
         if data.state:
-            query_kw['review_state'] = data.state
+            query['review_state'] = data.state
 
         events = []
-        query_kw.update(self.request.get('contentFilter', {}))
+        query.update(self.request.get('contentFilter', {}))
         search_base = self.search_base
         if ICollection.providedBy(search_base):
-            query = queryparser.parseFormquery(search_base, search_base.query)
+            # Whatever sorting is defined, we're overriding it.
+            query = queryparser.parseFormquery(
+                search_base, search_base.query,
+                sort_on='start', sort_order=None
+            )
 
             start = None
             if 'start' in query:
@@ -170,24 +174,25 @@ class Renderer(base.Renderer):
                 end = query['end']
 
             start, end = _prepare_range(search_base, start, end)
-            query_kw.update(start_end_query(start, end))
+            query.update(start_end_query(start, end))
             events = search_base.results(
-                batch=False, brains=True, custom_query=query_kw,
+                batch=False, brains=True, custom_query=query,
                 limit=data.count
             )
             events = expand_events(
                 events, ret_mode=RET_MODE_ACCESSORS,
-                sort='start', start=start, end=end
+                start=start, end=end,
+                sort='start', sort_reverse=False
             )
             events = events[:data.count]  # limit expanded
         else:
             search_base_path = self.search_base_path
             if search_base_path:
-                query_kw['path'] = {'query': search_base_path}
+                query['path'] = {'query': search_base_path}
             events = get_events(
                 context, start=localized_now(context),
                 ret_mode=RET_MODE_ACCESSORS,
-                expand=True, limit=data.count, **query_kw
+                expand=True, limit=data.count, **query
             )
         return events
 


### PR DESCRIPTION
Extend Collection support on ``event_listing`` for content items providing ``ISyndicatableCollection``.

For ``event_listing`` on Collections, ignore the Collection's sorting and use  what the event listing's mode defines for sorting.

Add support for Collections as data source for calendar and event portlets.