### PR TITLE
unwrap search_base in portlets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 2.0a12 (unreleased)
 -------------------
 
+- Unwrap search_base for portlets, as it might be wrapped by the portlet
+  renderer class. Fixes an error with getting the events to display.
+  [thet]
+
 - Import BBB superclasses from  plone.app.portlets.portlets.base so it works
   with plone.app.portlets 3.0 and up
   [frapell]

--- a/plone/app/event/portlets/portlet_calendar.py
+++ b/plone/app/event/portlets/portlet_calendar.py
@@ -105,7 +105,8 @@ class Renderer(base.Renderer):
     def search_base(self):
         if not self._search_base:
             self._search_base = uuidToObject(self.data.search_base_uid)
-        return self._search_base
+        # aq_inner, because somehow search_base gets wrapped by the renderer
+        return aq_inner(self._search_base)
 
     @property
     def search_base_path(self):

--- a/plone/app/event/portlets/portlet_events.py
+++ b/plone/app/event/portlets/portlet_events.py
@@ -111,7 +111,8 @@ class Renderer(base.Renderer):
     def search_base(self):
         if not self._search_base:
             self._search_base = uuidToObject(self.data.search_base_uid)
-        return self._search_base
+        # aq_inner, because somehow search_base gets wrapped by the renderer
+        return aq_inner(self._search_base)
 
     @property
     def search_base_path(self):


### PR DESCRIPTION
Unwrap search_base for portlets, as it might be wrapped by the portlet renderer class. Fixes an error with getting the events to display.