### PR TITLE
date speller changes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 2.0a13 (unreleased)
 -------------------
 
+- Let ``date_speller`` return the short, 2-letter weekday abbreviation instead
+  of a 3-letter one.
+  [thet]
+
 - Remove inconsistency in date_speller and rename ``month`` and ``wkday`` keys
   to ``month_name`` and ``wkday_name``. Introduce ``month``, the non-zero
   padded numeric value of the current month, ``month2``, the zero-padded one,

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,12 @@ Changelog
 2.0a13 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Remove inconsistency in date_speller and rename ``month`` and ``wkday`` keys
+  to ``month_name`` and ``wkday_name``. Introduce ``month``, the non-zero
+  padded numeric value of the current month, ``month2``, the zero-padded one,
+  ``wkday``, the weekday number and ``week``, the weeknumber of the current
+  year.
+  [thet]
 
 
 2.0a12 (2015-06-05)

--- a/plone/app/event/base.py
+++ b/plone/app/event/base.py
@@ -847,21 +847,23 @@ def date_speller(context, dt):
     date_dict = dict(
         year=dt.year(),
 
-        month=util.translate(
+        month=dt.month(),
+        month2=zero_pad(dt.month()),
+        month_name=util.translate(
             util.month_msgid(dt.month()),
             domain=dom, context=context
         ),
-
         month_abbr=util.translate(
             util.month_msgid(dt.month(), 'a'),
             domain=dom, context=context
         ),
 
-        wkday=util.translate(
+        week=dt.week(),
+        wkday=dt.dow(),
+        wkday_name=util.translate(
             util.day_msgid(dt.dow()),
             domain=dom, context=context
         ),
-
         wkday_abbr=util.translate(
             util.day_msgid(dt.dow(), 'a'),
             domain=dom, context=context

--- a/plone/app/event/base.py
+++ b/plone/app/event/base.py
@@ -865,7 +865,7 @@ def date_speller(context, dt):
             domain=dom, context=context
         ),
         wkday_abbr=util.translate(
-            util.day_msgid(dt.dow(), 'a'),
+            util.day_msgid(dt.dow(), 's'),
             domain=dom, context=context
         ),
 

--- a/plone/app/event/browser/event_listing.py
+++ b/plone/app/event/browser/event_listing.py
@@ -276,15 +276,15 @@ class EventListing(BrowserView):
                 default=u"${from} until ${until}.",
                 mapping={
                     'from': "%s, %s. %s %s" % (
-                        start_dict['wkday'],
+                        start_dict['wkday_name'],
                         start.day,
-                        start_dict['month'],
+                        start_dict['month_name'],
                         start.year
                     ),
                     'until': "%s, %s. %s %s" % (
-                        end_dict['wkday'],
+                        end_dict['wkday_name'],
                         end.day,
-                        end_dict['month'],
+                        end_dict['month_name'],
                         end.year
                     ),
                 }
@@ -296,9 +296,9 @@ class EventListing(BrowserView):
                 default=u"Events on ${day}",
                 mapping={
                     'day': "%s, %s. %s %s" % (
-                        start_dict['wkday'],
+                        start_dict['wkday_name'],
                         start.day,
-                        start_dict['month'],
+                        start_dict['month_name'],
                         start.year
                     ),
                 }
@@ -313,15 +313,15 @@ class EventListing(BrowserView):
                 default=u"${from} until ${until}.",
                 mapping={
                     'from': "%s, %s. %s %s" % (
-                        start_dict['wkday'],
+                        start_dict['wkday_name'],
                         start.day,
-                        start_dict['month'],
+                        start_dict['month_name'],
                         start.year
                     ),
                     'until': "%s, %s. %s %s" % (
-                        end_dict['wkday'],
+                        end_dict['wkday_name'],
                         end.day,
-                        end_dict['month'],
+                        end_dict['month_name'],
                         end.year
                     ),
                 }
@@ -332,7 +332,7 @@ class EventListing(BrowserView):
                 u"events_in_month",
                 default=u"Events in ${month} ${year}",
                 mapping={
-                    'month': start_dict['month'],
+                    'month': start_dict['month_name'],
                     'year': start.year,
                 }
             )

--- a/plone/app/event/tests/test_base_module.py
+++ b/plone/app/event/tests/test_base_module.py
@@ -10,6 +10,7 @@ from plone.app.event.base import RET_MODE_ACCESSORS
 from plone.app.event.base import RET_MODE_OBJECTS
 from plone.app.event.base import construct_calendar
 from plone.app.event.base import dates_for_display
+from plone.app.event.base import date_speller
 from plone.app.event.base import default_end
 from plone.app.event.base import default_start
 from plone.app.event.base import default_timezone
@@ -299,6 +300,30 @@ class TestBaseModule(unittest.TestCase):
             end.year == 2013 and end.month == 2 and end.day == 28 and
             end.hour == 23 and end.minute == 59 and end.second == 59
         )
+
+    def test_date_speller(self):
+        DT = DateTime(2015, 6, 6, 1, 2, 3)
+        date_spelled = date_speller(self.portal, DT)
+        self.assertEqual(date_spelled['year'], 2015)
+        self.assertEqual(date_spelled['month'], 6)
+        self.assertEqual(date_spelled['month2'], '06')
+        self.assertEqual(date_spelled['day'], 6)
+        self.assertEqual(date_spelled['day2'], '06')
+        self.assertEqual(date_spelled['hour'], 1)
+        self.assertEqual(date_spelled['hour2'], '01')
+        self.assertEqual(date_spelled['minute'], 2)
+        self.assertEqual(date_spelled['minute2'], '02')
+        self.assertEqual(date_spelled['second'], 3)
+        self.assertEqual(date_spelled['second2'], '03')
+        self.assertEqual(date_spelled['week'], 23)
+
+        # locale specific
+        # TODO: test better.
+        self.assertTrue(isinstance(date_spelled['wkday'], int))
+        self.assertTrue(isinstance(date_spelled['month_name'], basestring))
+        self.assertTrue(isinstance(date_spelled['month_abbr'], basestring))
+        self.assertTrue(isinstance(date_spelled['wkday_name'], basestring))
+        self.assertTrue(isinstance(date_spelled['wkday_abbr'], basestring))
 
 
 class TimezoneTest(unittest.TestCase):


### PR DESCRIPTION
Remove inconsistency in date_speller and rename ``month`` and ``wkday`` keys
to ``month_name`` and ``wkday_name``. Introduce ``month``, the non-zero
padded numeric value of the current month, ``month2``, the zero-padded one,
``wkday``, the weekday number and ``week``, the weeknumber of the current
year.