### PR TITLE
removing dependency on p.a.contenttypes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,12 @@ Changelog
 2.0b2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- initialize events.js javascript after all patterns are initialized.
+  [garbas]
+
+- removing dependency on plone.app.contenttypes that introduce with latest
+  changes to portlets code.
+  [garbas]
 
 
 2.0b1 (2015-07-18)

--- a/plone/app/event/browser/resources/event.js
+++ b/plone/app/event/browser/resources/event.js
@@ -134,8 +134,7 @@ require([
         }
     }
 
-
-    $(window).load(function () {
+    function initilize_event() {
 
         // EDIT FORM
 
@@ -172,5 +171,16 @@ require([
         // EVENT LISTING CALENDAR POPUP
         event_listing_calendar_init($("#event_listing_calendar"));
 
-    });
+    };
+
+    // mockup-core should trigger event once it initiallized all patterns (in
+    // mockup-core) but it only sets body class once all patterns were
+    // initialized
+    var interval = setInterval(function(){
+      if ($(document.body).hasClass('patterns-loaded')) {
+        clearInterval(interval);
+        initilize_event();
+      }
+    }, 100);
+ 
 });

--- a/plone/app/event/portlets/portlet_calendar.py
+++ b/plone/app/event/portlets/portlet_calendar.py
@@ -2,8 +2,6 @@ from Acquisition import aq_inner
 from ComputedAttribute import ComputedAttribute
 from Products.CMFCore.utils import getToolByName
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from plone.app.contenttypes.behaviors.collection import ISyndicatableCollection
-from plone.app.contenttypes.interfaces import IFolder
 from plone.app.event.base import RET_MODE_OBJECTS
 from plone.app.event.base import _prepare_range
 from plone.app.event.base import expand_events
@@ -30,7 +28,16 @@ import json
 
 try:
     from plone.app.contenttypes.behaviors.collection import ISyndicatableCollection as ICollection  # noqa
+    from plone.app.contenttypes.interfaces import IFolder
+    search_base_uid_source = CatalogSource(object_provides={
+        'query': [
+            ICollection.__identifier__,
+            IFolder.__identifier__
+        ],
+        'operator': 'or'
+    })
 except ImportError:
+    search_base_uid_source = CatalogSource(is_folderish=True)
     ICollection = None
 
 PLMF = MessageFactory('plonelocales')
@@ -60,13 +67,7 @@ class ICalendarPortlet(IPortletDataProvider):
                     u'called on the site root.'
         ),
         required=False,
-        source=CatalogSource(object_provides={
-            'query': [
-                ISyndicatableCollection.__identifier__,
-                IFolder.__identifier__
-            ],
-            'operator': 'or'
-        }),
+        source=search_base_uid_source,
     )
 
 
@@ -208,7 +209,7 @@ class Renderer(base.Renderer):
         events = []
         query.update(self.request.get('contentFilter', {}))
         search_base = self.search_base
-        if ICollection.providedBy(search_base):
+        if ICollection and ICollection.providedBy(search_base):
             # Whatever sorting is defined, we're overriding it.
             query = queryparser.parseFormquery(
                 search_base, search_base.query,

--- a/plone/app/event/portlets/portlet_events.py
+++ b/plone/app/event/portlets/portlet_events.py
@@ -2,8 +2,6 @@ from Acquisition import aq_inner
 from ComputedAttribute import ComputedAttribute
 from Products.CMFCore.utils import getToolByName
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from plone.app.contenttypes.behaviors.collection import ISyndicatableCollection
-from plone.app.contenttypes.interfaces import IFolder
 from plone.app.event.base import expand_events
 from plone.app.event.base import _prepare_range
 from plone.app.event.base import start_end_query
@@ -27,7 +25,16 @@ from plone.app.querystring import queryparser
 
 try:
     from plone.app.contenttypes.behaviors.collection import ISyndicatableCollection as ICollection  # noqa
+    from plone.app.contenttypes.interfaces import IFolder
+    search_base_uid_source = CatalogSource(object_provides={
+        'query': [
+            ICollection.__identifier__,
+            IFolder.__identifier__
+        ],
+        'operator': 'or'
+    })
 except ImportError:
+    search_base_uid_source = CatalogSource(is_folderish=True)
     ICollection = None
 
 
@@ -61,13 +68,7 @@ class IEventsPortlet(IPortletDataProvider):
                     u'called on the site root.'
         ),
         required=False,
-        source=CatalogSource(object_provides={
-            'query': [
-                ISyndicatableCollection.__identifier__,
-                IFolder.__identifier__
-            ],
-            'operator': 'or'
-        }),
+        source=search_base_uid_source,
     )
 
 
@@ -155,7 +156,7 @@ class Renderer(base.Renderer):
         events = []
         query.update(self.request.get('contentFilter', {}))
         search_base = self.search_base
-        if ICollection.providedBy(search_base):
+        if ICollection and ICollection.providedBy(search_base):
             # Whatever sorting is defined, we're overriding it.
             query = queryparser.parseFormquery(
                 search_base, search_base.query,

--- a/plone/app/event/portlets/portlet_events.py
+++ b/plone/app/event/portlets/portlet_events.py
@@ -5,15 +5,16 @@ from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from plone.app.event.base import expand_events
 from plone.app.event.base import _prepare_range
 from plone.app.event.base import start_end_query
-
 from plone.app.event.base import RET_MODE_ACCESSORS
 from plone.app.event.base import get_events
 from plone.app.event.base import localized_now
 from plone.app.event.portlets import get_calendar_url
+from plone.app.event.portlets.portlet_events import (
+    ICollection, search_base_uid_source
+)
 from plone.app.portlets import PloneMessageFactory as _
 from plone.app.portlets.portlets import base
 from plone.app.uuid.utils import uuidToObject
-from plone.app.vocabularies.catalog import CatalogSource
 from plone.memoize.compress import xhtml_compress
 from plone.portlets.interfaces import IPortletDataProvider
 from zExceptions import NotFound
@@ -22,20 +23,6 @@ from zope.component import getMultiAdapter
 from zope.contentprovider.interfaces import IContentProvider
 from zope.interface import implementer
 from plone.app.querystring import queryparser
-
-try:
-    from plone.app.contenttypes.behaviors.collection import ISyndicatableCollection as ICollection  # noqa
-    from plone.app.contenttypes.interfaces import IFolder
-    search_base_uid_source = CatalogSource(object_provides={
-        'query': [
-            ICollection.__identifier__,
-            IFolder.__identifier__
-        ],
-        'operator': 'or'
-    })
-except ImportError:
-    search_base_uid_source = CatalogSource(is_folderish=True)
-    ICollection = None
 
 
 class IEventsPortlet(IPortletDataProvider):


### PR DESCRIPTION
after some time back to plone development :)

plone 4.3. i'm only want to use p.a.event without p.a.contenttypes. it is an addon and there is no need to depend on p.a.contenttypes.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/plone/plone.app.event/195)
<!-- Reviewable:end -->
