### PR TITLE
No need for unittest2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Remove unittest2 dependency.
+  [gforcada]
 
 2.0 (2015-09-11)
 ----------------

--- a/plone/app/event/tests/base_setup.py
+++ b/plone/app/event/tests/base_setup.py
@@ -8,7 +8,7 @@ from plone.app.testing import TEST_USER_ID
 from plone.app.testing import setRoles
 from plone.dexterity.utils import createContentInContainer
 
-import unittest2 as unittest
+import unittest
 import pytz
 
 TEST_TIMEZONE = 'Europe/Vienna'

--- a/plone/app/event/tests/test_base_module.py
+++ b/plone/app/event/tests/test_base_module.py
@@ -40,7 +40,7 @@ from zope.interface import directlyProvides
 
 
 import pytz
-import unittest2 as unittest
+import unittest
 
 
 class TestBaseModule(unittest.TestCase):

--- a/plone/app/event/tests/test_catalog.py
+++ b/plone/app/event/tests/test_catalog.py
@@ -1,7 +1,7 @@
 from Products.CMFCore.utils import getToolByName
 from plone.app.event.testing import PAEvent_INTEGRATION_TESTING
 
-import unittest2 as unittest
+import unittest
 
 
 class TextDXIntegration(unittest.TestCase):

--- a/plone/app/event/tests/test_dx_behaviors.py
+++ b/plone/app/event/tests/test_dx_behaviors.py
@@ -32,7 +32,7 @@ from zope.annotation.interfaces import IAnnotations
 
 import mock
 import pytz
-import unittest2 as unittest
+import unittest
 import zope.interface
 
 

--- a/plone/app/event/tests/test_icalendar.py
+++ b/plone/app/event/tests/test_icalendar.py
@@ -14,7 +14,7 @@ from zope.component import getMultiAdapter
 
 import os
 import pytz
-import unittest2 as unittest
+import unittest
 
 
 # TODO:

--- a/plone/app/event/tests/test_portlet_calendar.py
+++ b/plone/app/event/tests/test_portlet_calendar.py
@@ -25,7 +25,7 @@ from zope.component.hooks import setHooks
 from zope.component.hooks import setSite
 
 import pytz
-import unittest2 as unittest
+import unittest
 
 
 TZNAME = 'Europe/Vienna'

--- a/plone/app/event/tests/test_portlet_events.py
+++ b/plone/app/event/tests/test_portlet_events.py
@@ -26,7 +26,7 @@ from zope.component.hooks import setSite
 from zope.interface import alsoProvides
 
 import pytz
-import unittest2 as unittest
+import unittest
 
 TZNAME = 'Australia/Brisbane'
 PTYPE = 'plone.app.event.dx.event'

--- a/plone/app/event/tests/test_recurrence.py
+++ b/plone/app/event/tests/test_recurrence.py
@@ -28,7 +28,7 @@ from mock import Mock
 import datetime
 import pytz
 import transaction
-import unittest2 as unittest
+import unittest
 import zope.component
 
 

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,6 @@ setup(
             'plone.testing',
             'robotsuite',
             'transaction',
-            'unittest2',
             'zExceptions',
             'zope.event',
         ],


### PR DESCRIPTION
Since python 2.7 unittest2 was already merged with unittest.