### PR TITLE
Add start and end getters for dx EventAccessor

### DIFF
--- a/plone/app/event/dx/behaviors.py
+++ b/plone/app/event/dx/behaviors.py
@@ -2,6 +2,7 @@
 """
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
+from datetime import datetime
 from datetime import timedelta
 from datetime import tzinfo
 from plone.app.dexterity.behaviors.metadata import ICategorization
@@ -708,3 +709,17 @@ class EventAccessor(object):
     @text.setter
     def text(self, value):
         self.context.text = RichTextValue(raw=safe_unicode(value))
+
+    @property
+    def start(self):
+        value = getattr(self.context, 'start', None)
+        if value is None:
+            return datetime.now()
+        return value
+
+    @property
+    def end(self):
+        value = getattr(self.context, 'end', None)
+        if value is None:
+            return datetime.now()
+        return value

--- a/plone/app/event/dx/behaviors.py
+++ b/plone/app/event/dx/behaviors.py
@@ -422,7 +422,10 @@ class EventBasic(object):
 
     def _prepare_dt_get(self, dt):
         # always get the date in event's timezone
-        return dt_to_zone(dt, self.context.timezone)
+        if self.timezone:
+            return dt_to_zone(dt, self.timezone)
+        else:
+            return dt
 
     def _prepare_dt_set(self, dt):
         # Dates are always set in UTC, saving the actual timezone in another
@@ -712,14 +715,16 @@ class EventAccessor(object):
 
     @property
     def start(self):
-        value = getattr(self.context, 'start', None)
-        if value is None:
-            return datetime.now()
-        return value
+        start = IEventBasic(self.context).start
+        if self.whole_day:
+            start = dt_start_of_day(start)
+        return start
 
     @property
     def end(self):
-        value = getattr(self.context, 'end', None)
-        if value is None:
-            return datetime.now()
-        return value
+        end = IEventBasic(self.context).end
+        if self.open_end:
+            end = IEventBasic(self.context).start
+        if self.open_end or self.whole_day:
+            end = dt_end_of_day(end)
+        return end


### PR DESCRIPTION
This PR fix this issues https://github.com/plone/plone.app.contenttypes/issues/285
The way to get occurrence/event change in 1.2.x versions, so it's only fix 1.1.x issue.