### PR TITLE
Index1445 calendarwidget

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,14 @@
 Changelog
 =========
+2.0.6 (2016-03-16)
+------------------
+
+Fixes:
+
+- Changed the color of the navigation icon in the Calendar portlet, from the 
+  default blue color of the <a> tag to the inherited grey color.
+  [janga1997]
+
 
 2.0.7 (unreleased)
 ------------------

--- a/plone/app/event/browser/resources/event.css
+++ b/plone/app/event/browser/resources/event.css
@@ -169,6 +169,10 @@ article.vevent a.event_ical img {
     margin: 0 -.5em;
 }
 
+a.calendarNext,a.calendarPrevious{
+    color:inherit !important;
+}
+
 .portletCalendar a, .portletCalendar a:focus,
 .portletCalendar a, .portletCalendar a:hover,
 .ploneCalendar a {


### PR DESCRIPTION
Changed the color of the navigation on the calendar widget, to the inherited grey color, from the previous default blue color.