### PR TITLE
More graceful dates_for_display when no start/end

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,9 @@ New:
 
 Fixes:
 
-- *add item here*
+- Don't break ``base.dates_for_display`` and the ``formatted_date`` content provider, if event object has no start or end dates.
+  It might come from a potential event.
+  [thet]
 
 
 2.0.7 (2016-03-31)

--- a/plone/app/event/base.py
+++ b/plone/app/event/base.py
@@ -792,6 +792,10 @@ def dates_for_display(occurrence):
     else:
         acc = IEventAccessor(occurrence)
 
+    if acc.start is None or acc.end is None:
+        # Eventually optional start/end dates from a potentially Event.
+        return None
+
     # this needs to separate date and time as ulocalized_time does
     DT_start = DT(acc.start)
     DT_end = DT(acc.end)

--- a/plone/app/event/browser/formatted_date.py
+++ b/plone/app/event/browser/formatted_date.py
@@ -21,6 +21,9 @@ class FormattedDateProvider(Explicit):
 
         """
         self.date_dict = dates_for_display(occ)
+        if self.date_dict is None:
+            # Don't break for potential Events without start/end.
+            return u""
         return self.template(self)
 
 


### PR DESCRIPTION
Don't break ``base.dates_for_display`` and the ``formatted_date`` content provider, if event object has no start or end dates.
It might come from a potential event.