### PR TITLE
Don't validate empty start/end

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Don't validate the ``validate_start_end`` invariant, if start or end are ``None``.
+  This can happen on non-required, default empty start or end fields during editing.
+  [thet]
 
 
 2.0.9 (2016-05-15)

--- a/plone/app/event/dx/behaviors.py
+++ b/plone/app/event/dx/behaviors.py
@@ -134,8 +134,12 @@ class IEventBasic(model.Schema, IDXEvent):
 
     @invariant
     def validate_start_end(data):
-        # data_postprocessing sets end=start if open_end
-        if data.start > data.end and not data.open_end:
+        if (
+            data.start
+            and data.end
+            and data.start > data.end
+            and not data.open_end
+        ):
             raise StartBeforeEnd(
                 _("error_end_must_be_after_start_date",
                   default=u"End date must be after start date.")

--- a/plone/app/event/tests/test_dx_behaviors.py
+++ b/plone/app/event/tests/test_dx_behaviors.py
@@ -444,6 +444,34 @@ class TestDXEventUnittest(unittest.TestCase):
         except:
             self.fail()
 
+    def test_validate_dont_validate_incomplete(self):
+        """Don't validate validate_start_end invariant, if start or end are
+        None.
+        """
+        mock = MockEvent()
+        mock.open_end = False
+
+        mock.start = datetime(2016, 5, 18)
+        mock.end = None
+        try:
+            IEventBasic.validateInvariants(mock)
+        except:
+            self.fail()
+
+        mock.start = None
+        mock.end = datetime(2016, 5, 18)
+        try:
+            IEventBasic.validateInvariants(mock)
+        except:
+            self.fail()
+
+        mock.start = None
+        mock.end = None
+        try:
+            IEventBasic.validateInvariants(mock)
+        except:
+            self.fail()
+
 
 class TestDXAnnotationStorageUpdate(unittest.TestCase):
     """ Unit tests for the Annotation Storage migration


### PR DESCRIPTION
Don't validate the ``validate_start_end`` invariant, if start or end are ``None``.
This can happen on non-required, default empty start or end fields during editing.