### PR TITLE
plone.autoform.directives and more generic javascript

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,9 @@ Breaking changes:
 
 New features:
 
+- Make JavaScript date/time update work with optional start/end dates.
+  [thet]
+
 - Make use of more generic selectors in JavaScript, so that JavaScript works also for derived classes.
   [thet]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Use ``plone.autoform.directives`` for manipulating field widgets instead of overriding the default Fieldwidget adapters.
+  [thet]
 
 Bug fixes:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,15 @@
 Changelog
 =========
 
-2.0.10 (unreleased)
--------------------
+3.0.0 (unreleased)
+------------------
 
 Breaking changes:
+
+.. note::
+    This release depends on ``plone.app.z3cform >= 2.0.1``, which is only available for Plone 5.1.
+    This is a backwards incompatible change, which satisfy a major version change for plone.app.event.
+    Consequently, Plone 4 compatibility code will be removed in this release.
 
 - *add item here*
 
@@ -15,6 +20,7 @@ New features:
 
 - Configure custom css classes for all event behavior fields.
   This makes it easier to use same selectors also for derived behaviors.
+  Needs ``plone.app.z3cform >= 2.0.1``.
   [thet]
 
 - Use ``plone.autoform.directives`` for manipulating field widgets instead of overriding the default Fieldwidget adapters.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ Breaking changes:
 
 New features:
 
+- Make use of more generic selectors in JavaScript, so that JavaScript works also for derived classes.
+  [thet]
+
 - Configure custom css classes for all event behavior fields.
   This makes it easier to use same selectors also for derived behaviors.
   [thet]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ Breaking changes:
 
 New features:
 
+- Configure custom css classes for all event behavior fields.
+  This makes it easier to use same selectors also for derived behaviors.
+  [thet]
+
 - Use ``plone.autoform.directives`` for manipulating field widgets instead of overriding the default Fieldwidget adapters.
   [thet]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ New features:
 
 Bug fixes:
 
+- Remove Archetypes based JavaScript code.
+  [thet]
+
 - Don't validate the ``validate_start_end`` invariant, if start or end are ``None``.
   This can happen on non-required, default empty start or end fields during editing.
   [thet]

--- a/plone/app/event/browser/resources/event.js
+++ b/plone/app/event/browser/resources/event.js
@@ -1,12 +1,12 @@
-/*jslint browser: true*/
-/*global $, jQuery, plone, require*/
+/* jslint browser: true */
+/* globals require */
 
 
 if(require === undefined){
   require = function(reqs, torun){
     'use strict';
     return torun(window.jQuery);
-  }
+  };
 }
 
 
@@ -16,16 +16,6 @@ require([
     'use strict';
 
     var end_start_delta = 1 / 24;  // Delta in days
-
-    function a_or_b(a, b) {
-        var ret;
-        if (a.length > 0) {
-            ret = a;
-        } else {
-            ret = b;
-        }
-        return ret;
-    }
 
     function getDateTime(datetimewidget) {
         var date, time, datetime;
@@ -50,16 +40,16 @@ require([
 
     function initDelta() {
         var start_datetime, end_datetime;
-        start_datetime = getDateTime(a_or_b($('#formfield-form-widgets-IEventBasic-start'), $('#archetypes-fieldname-startDate')));
-        end_datetime = getDateTime(a_or_b($('#formfield-form-widgets-IEventBasic-end'), $('#archetypes-fieldname-endDate')));
+        start_datetime = getDateTime($('#formfield-form-widgets-IEventBasic-start'));
+        end_datetime = getDateTime($('#formfield-form-widgets-IEventBasic-end'));
         // delta in days
         end_start_delta = (end_datetime - start_datetime) / 1000 / 60;
     }
 
     function updateEndDate() {
         var jq_start, jq_end, start_date, new_end_date;
-        jq_start = a_or_b($('#formfield-form-widgets-IEventBasic-start'), $('#archetypes-fieldname-startDate'));
-        jq_end = a_or_b($('#formfield-form-widgets-IEventBasic-end'), $('#archetypes-fieldname-endDate'));
+        jq_start = $('#formfield-form-widgets-IEventBasic-start');
+        jq_end = $('#formfield-form-widgets-IEventBasic-end');
 
         start_date = getDateTime(jq_start);
         new_end_date = new Date(start_date);
@@ -71,8 +61,8 @@ require([
 
     function validateEndDate() {
         var jq_start, jq_end, start_datetime, end_datetime;
-        jq_start = a_or_b($('#formfield-form-widgets-IEventBasic-start'), $('#archetypes-fieldname-startDate'));
-        jq_end = a_or_b($('#formfield-form-widgets-IEventBasic-end'), $('#archetypes-fieldname-endDate'));
+        jq_start = $('#formfield-form-widgets-IEventBasic-start');
+        jq_end = $('#formfield-form-widgets-IEventBasic-end');
 
         start_datetime = getDateTime(jq_start);
         end_datetime = getDateTime(jq_end);
@@ -141,24 +131,23 @@ require([
         var jq_whole_day, jq_time, jq_open_end, jq_end, jq_start;
 
         // WHOLE DAY INIT
-        jq_whole_day = a_or_b($('#formfield-form-widgets-IEventBasic-whole_day input'), $('form[name="edit_form"] input#wholeDay'));
-        jq_time = a_or_b($('#formfield-form-widgets-IEventBasic-start .pattern-pickadate-time-wrapper, #formfield-form-widgets-IEventBasic-end .pattern-pickadate-time-wrapper'),
-                         $('#archetypes-fieldname-startDate .pattern-pickadate-time-wrapper, #archetypes-fieldname-endDate .pattern-pickadate-time-wrapper'));
+        jq_whole_day = $('#formfield-form-widgets-IEventBasic-whole_day input');
+        jq_time = $('#formfield-form-widgets-IEventBasic-start .pattern-pickadate-time-wrapper, #formfield-form-widgets-IEventBasic-end .pattern-pickadate-time-wrapper');
         if (jq_whole_day.length > 0) {
             jq_whole_day.bind('change', function (e) { show_hide_widget(jq_time, e.target.checked, true); });
             show_hide_widget(jq_time, jq_whole_day.get(0).checked, false);
         }
 
         // OPEN END INIT
-        jq_open_end = a_or_b($('#formfield-form-widgets-IEventBasic-open_end input'), $('form[name="edit_form"] input#openEnd'));
-        jq_end = a_or_b($('#formfield-form-widgets-IEventBasic-end'), $('#archetypes-fieldname-endDate'));
+        jq_open_end = $('#formfield-form-widgets-IEventBasic-open_end input');
+        jq_end = $('#formfield-form-widgets-IEventBasic-end');
         if (jq_open_end.length > 0) {
             jq_open_end.bind('change', function (e) { show_hide_widget(jq_end, e.target.checked, true); });
             show_hide_widget(jq_end, jq_open_end.get(0).checked, false);
         }
 
         // START/END SETTING/VALIDATION
-        jq_start = a_or_b($('#formfield-form-widgets-IEventBasic-start'), $('#archetypes-fieldname-startDate'));
+        jq_start = $('#formfield-form-widgets-IEventBasic-start');
         jq_start.each(function () {
             $(this).on('focus', '.picker__input', initDelta);
             $(this).on('change', '.picker__input', updateEndDate);
@@ -171,7 +160,7 @@ require([
         // EVENT LISTING CALENDAR POPUP
         event_listing_calendar_init($("#event_listing_calendar"));
 
-    };
+    }
 
     // mockup-core should trigger event once it initiallized all patterns (in
     // mockup-core) but it only sets body class once all patterns were

--- a/plone/app/event/browser/resources/event.js
+++ b/plone/app/event/browser/resources/event.js
@@ -38,39 +38,30 @@ require([
         return datetime;
     }
 
-    function initDelta() {
-        var start_datetime, end_datetime;
-        start_datetime = getDateTime($('#formfield-form-widgets-IEventBasic-start'));
-        end_datetime = getDateTime($('#formfield-form-widgets-IEventBasic-end'));
+    function initDelta(a, b) {
+        var start_datetime = getDateTime(a);
+        var end_datetime = getDateTime(b);
         // delta in days
         end_start_delta = (end_datetime - start_datetime) / 1000 / 60;
     }
 
-    function updateEndDate() {
-        var jq_start, jq_end, start_date, new_end_date;
-        jq_start = $('#formfield-form-widgets-IEventBasic-start');
-        jq_end = $('#formfield-form-widgets-IEventBasic-end');
-
-        start_date = getDateTime(jq_start);
-        new_end_date = new Date(start_date);
+    function updateEndDate(start_container, end_container) {
+        var start_date = getDateTime(start_container);
+        var new_end_date = new Date(start_date);
         new_end_date.setMinutes(start_date.getMinutes() + end_start_delta);
 
-        $('.pattern-pickadate-date', jq_end).pickadate('picker').set('select', new_end_date);
-        $('.pattern-pickadate-time', jq_end).pickatime('picker').set('select', new_end_date);
+        $('.pattern-pickadate-date', end_container).pickadate('picker').set('select', new_end_date);
+        $('.pattern-pickadate-time', end_container).pickatime('picker').set('select', new_end_date);
     }
 
-    function validateEndDate() {
-        var jq_start, jq_end, start_datetime, end_datetime;
-        jq_start = $('#formfield-form-widgets-IEventBasic-start');
-        jq_end = $('#formfield-form-widgets-IEventBasic-end');
-
-        start_datetime = getDateTime(jq_start);
-        end_datetime = getDateTime(jq_end);
+    function validateEndDate(start_container, end_container) {
+        var start_datetime = getDateTime(start_container);
+        var end_datetime = getDateTime(end_container);
 
         if (end_datetime < start_datetime) {
-            jq_end.addClass("error");
+            start_container.addClass("error");
         } else {
-            jq_end.removeClass("error");
+            end_container.removeClass("error");
         }
     }
 
@@ -127,32 +118,41 @@ require([
     function initilize_event() {
 
         // EDIT FORM
-
-        var jq_whole_day, jq_time, jq_open_end, jq_end, jq_start;
+        var $start_input         = $('form input.event_start');
+        var $start_container     = $start_input.closest('div');
+        var $pickadate_starttime = $('.pattern-pickadate-time-wrapper', $start_container);
+        
+        var $end_input           = $('form input.event_end');
+        var $end_container       = $end_input.closest('div');
+        var $pickadate_endtime   = $('.pattern-pickadate-time-wrapper', $end_container);
+        
+        var $whole_day_input     = $('form input.event_whole_day');
+        var $open_end_input      = $('form input.open_end_input');
 
         // WHOLE DAY INIT
-        jq_whole_day = $('#formfield-form-widgets-IEventBasic-whole_day input');
-        jq_time = $('#formfield-form-widgets-IEventBasic-start .pattern-pickadate-time-wrapper, #formfield-form-widgets-IEventBasic-end .pattern-pickadate-time-wrapper');
-        if (jq_whole_day.length > 0) {
-            jq_whole_day.bind('change', function (e) { show_hide_widget(jq_time, e.target.checked, true); });
-            show_hide_widget(jq_time, jq_whole_day.get(0).checked, false);
+        if ($whole_day_input.length > 0) {
+            $whole_day_input.bind('change', function (e) {
+              show_hide_widget($pickadate_starttime, e.target.checked, true);
+              show_hide_widget($pickadate_endtime, e.target.checked, true);
+            });
+            show_hide_widget($pickadate_starttime, $whole_day_input.get(0).checked, false);
+            show_hide_widget($pickadate_endtime, $whole_day_input.get(0).checked, false);
         }
 
         // OPEN END INIT
-        jq_open_end = $('#formfield-form-widgets-IEventBasic-open_end input');
-        jq_end = $('#formfield-form-widgets-IEventBasic-end');
-        if (jq_open_end.length > 0) {
-            jq_open_end.bind('change', function (e) { show_hide_widget(jq_end, e.target.checked, true); });
-            show_hide_widget(jq_end, jq_open_end.get(0).checked, false);
+        if ($open_end_input.length > 0) {
+            $open_end_input.bind('change', function (e) {
+              show_hide_widget($end_container, e.target.checked, true);
+            });
+            show_hide_widget($end_container, $open_end_input.get(0).checked, false);
         }
 
         // START/END SETTING/VALIDATION
-        jq_start = $('#formfield-form-widgets-IEventBasic-start');
-        jq_start.each(function () {
+        $start_container.each(function () {
             $(this).on('focus', '.picker__input', initDelta);
             $(this).on('change', '.picker__input', updateEndDate);
         });
-        jq_end.each(function () {
+        $end_container.each(function () {
             $(this).on('focus', '.picker__input', initDelta);
             $(this).on('change', '.picker__input', validateEndDate);
         });

--- a/plone/app/event/dx/behaviors.py
+++ b/plone/app/event/dx/behaviors.py
@@ -313,9 +313,9 @@ class IEventContact(model.Schema):
         default=None
     )
     directives.widget(
-        'contact_url',
+        'event_url',
         TextFieldWidget,
-        klass=u'event_contact_url'
+        klass=u'event_url'
     )
 
 

--- a/plone/app/event/dx/behaviors.py
+++ b/plone/app/event/dx/behaviors.py
@@ -26,6 +26,7 @@ from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import getFSVersionTuple
 from Products.CMFPlone.utils import safe_unicode
 from z3c.form.browser.checkbox import SingleCheckBoxFieldWidget
+from z3c.form.browser.text import TextFieldWidget
 from z3c.form.browser.textlines import TextLinesFieldWidget
 from zope import schema
 from zope.component import adapter
@@ -89,7 +90,8 @@ class IEventBasic(model.Schema, IDXEvent):
     directives.widget(
         'start',
         DatetimeFieldWidget,
-        default_timezone=default_timezone
+        default_timezone=default_timezone,
+        klass=u'event_start'
     )
 
     end = schema.Datetime(
@@ -107,7 +109,8 @@ class IEventBasic(model.Schema, IDXEvent):
     directives.widget(
         'end',
         DatetimeFieldWidget,
-        default_timezone=default_timezone
+        default_timezone=default_timezone,
+        klass=u'event_end'
     )
 
     whole_day = schema.Bool(
@@ -124,7 +127,8 @@ class IEventBasic(model.Schema, IDXEvent):
     )
     directives.widget(
         'whole_day',
-        SingleCheckBoxFieldWidget
+        SingleCheckBoxFieldWidget,
+        klass=u'event_whole_day'
     )
 
     open_end = schema.Bool(
@@ -141,7 +145,8 @@ class IEventBasic(model.Schema, IDXEvent):
     )
     directives.widget(
         'open_end',
-        SingleCheckBoxFieldWidget
+        SingleCheckBoxFieldWidget,
+        klass=u'event_open_end'
     )
 
     # icalendar event uid
@@ -183,7 +188,8 @@ class IEventRecurrence(model.Schema, IDXEventRecurrence):
         RecurrenceFieldWidget,
         start_field=u'IEventBasic.start',
         first_day=first_weekday_sun0,
-        show_repeat_forever=False
+        show_repeat_forever=False,
+        klass=u'event_recurrence'
     )
 
 
@@ -202,6 +208,11 @@ class IEventLocation(model.Schema):
         ),
         required=False,
         default=None
+    )
+    directives.widget(
+        'location',
+        TextFieldWidget,
+        klass=u'event_location'
     )
 
 
@@ -223,7 +234,11 @@ class IEventAttendees(model.Schema):
         missing_value=(),
         default=(),
     )
-    directives.widget(attendees=TextLinesFieldWidget)
+    directives.widget(
+        'attendees',
+        TextLinesFieldWidget,
+        klass=u'event_attendees'
+    )
 
 
 class IEventContact(model.Schema):
@@ -242,6 +257,11 @@ class IEventContact(model.Schema):
         required=False,
         default=None
     )
+    directives.widget(
+        'contact_name',
+        TextFieldWidget,
+        klass=u'event_contact_name'
+    )
 
     contact_email = schema.TextLine(
         title=_(
@@ -254,6 +274,11 @@ class IEventContact(model.Schema):
         ),
         required=False,
         default=None
+    )
+    directives.widget(
+        'contact_email',
+        TextFieldWidget,
+        klass=u'event_contact_email'
     )
 
     contact_phone = schema.TextLine(
@@ -268,6 +293,11 @@ class IEventContact(model.Schema):
         required=False,
         default=None
     )
+    directives.widget(
+        'contact_phone',
+        TextFieldWidget,
+        klass=u'event_contact_phone'
+    )
 
     event_url = schema.TextLine(
         title=_(
@@ -281,6 +311,11 @@ class IEventContact(model.Schema):
         ),
         required=False,
         default=None
+    )
+    directives.widget(
+        'contact_url',
+        TextFieldWidget,
+        klass=u'event_contact_url'
     )
 
 

--- a/plone/app/event/dx/configure.zcml
+++ b/plone/app/event/dx/configure.zcml
@@ -20,10 +20,6 @@
 
     <adapter factory=".behaviors.EventAccessor" />
 
-    <adapter factory=".behaviors.RecurrenceFieldWidget" />
-    <adapter factory=".behaviors.StartDateFieldWidget" />
-    <adapter factory=".behaviors.EndDateFieldWidget" />
-
     <adapter name="start" factory=".behaviors.start_indexer" />
     <adapter name="end" factory=".behaviors.end_indexer" />
     <adapter name="location" factory=".behaviors.location_indexer" />

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages
 import os
 
 
-version = '2.0.10.dev0'
+version = '3.0.dev0'
 
 
 setup(
@@ -53,7 +53,7 @@ setup(
         'plone.app.registry',
         'plone.app.textfield',
         'plone.app.vocabularies >= 2.1.15.dev0',
-        'plone.app.z3cform',
+        'plone.app.z3cform>=2.0.1.dev0',
         'plone.autoform>=1.4',
         'plone.behavior',
         'plone.browserlayer',


### PR DESCRIPTION
- Make use of more generic selectors in JavaScript, so that JavaScript works also for derived classes.
- Configure custom css classes for all event behavior fields.
  This makes it easier to use same selectors also for derived behaviors.
- Use ``plone.autoform.directives`` for manipulating field widgets instead of overriding the default Fieldwidget adapters.