### PR TITLE
Fixed dutch translations

### DIFF
--- a/plone/app/event/locales/nl/LC_MESSAGES/plone.app.event.po
+++ b/plone/app/event/locales/nl/LC_MESSAGES/plone.app.event.po
@@ -487,7 +487,7 @@ msgstr "Ical import-instellingen opgeslagen"
 #. Default: "There are ${results} more occurrences."
 #: plone/app/event/browser/event_summary.py:79
 msgid "msg_num_more_occurrences"
-msgstr "Er zijn nog ${resuls} andere momenten."
+msgstr "Er zijn nog ${results} andere momenten."
 
 #. Default: "Next Day"
 #: plone/app/event/browser/event_listing.pt:71


### PR DESCRIPTION
There is a mistake in the msgid "msg_num_more_occurrences":
“Er zijn nog ${resuls} andere momenten.”

It should be:
“Er zijn nog ${results} andere momenten.”