### PR TITLE
Fixed possible XSS attack in location field. [1.1]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,15 @@ Changelog
 1.1.5 (2015-09-08)
 ------------------
 
+Bug fixes:
+
+- Fixed possible cross site scripting (XSS) attack in location field.
+  If you had custom code to override the ``get_location`` view helper
+  method to return html, this no longer works.  For plain text it
+  still works fine, but the ``get_location`` method is gone in version
+  2.0, for simplicity.  Instead you can override the necessary
+  templates in your addons.  [maurits]
+
 - Ensure ``plone.formwidget.recurrence`` is ``<2.0dev``.
   [saily]
 

--- a/plone/app/event/browser/event_listing.pt
+++ b/plone/app/event/browser/event_listing.pt
@@ -103,7 +103,7 @@
             <div itemprop="location" class="location"
                 tal:define="location python:view.get_location(data)"
                 tal:condition="location"
-                tal:content="structure location">location</div>
+                tal:content="location">location</div>
           </div>
 
           <p itemprop="description" class="description" tal:condition="data/description" tal:content="data/description" />

--- a/plone/app/event/browser/event_summary.pt
+++ b/plone/app/event/browser/event_summary.pt
@@ -60,7 +60,7 @@
     <tal:cond condition="python:'location' not in excludes">
     <tal:cond define="location view/get_location" condition="location">
       <dt i18n:translate="event_where">Where</dt>
-      <dd itemprop="location" class="location" tal:content="structure location">Location</dd>
+      <dd itemprop="location" class="location" tal:content="location">Location</dd>
     </tal:cond>
     </tal:cond>
 

--- a/plone/app/event/portlets/portlet_events.pt
+++ b/plone/app/event/portlets/portlet_events.pt
@@ -35,7 +35,7 @@
             <span class="location"
                 tal:define="location python:view.get_location(item)"
                 tal:condition="location"> &mdash;
-                <tal:location content="structure location">Location</tal:location>
+                <tal:location content="location">Location</tal:location>
             </span>
         </span>
     </dd>


### PR DESCRIPTION
Note if you had custom code to override the get_location view helper method to return html, this no longer works.  For plain text it still works fine, but the get_location method is gone in version
2.0, for simplicity.  Instead you can override the necessary templates in your addons.