### PR TITLE
fix format of tooltip in calendar portlet 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,10 @@ New features:
 
 Bug fixes:
 
+- Fix format of tooltip in calendar portlet.
+  Fixes: https://github.com/plone/Products.CMFPlone/issues/1046
+  [fgrcon]
+
 - Fix bug when creating indexes on install. It was not detecting existing indexes correctly.
   [vangheem]
 

--- a/plone/app/event/portlets/portlet_calendar.py
+++ b/plone/app/event/portlets/portlet_calendar.py
@@ -252,7 +252,7 @@ class Renderer(base.Renderer):
             if isodat in cal_dict:
                 date_events = cal_dict[isodat]
 
-            events_string = u""
+            events_string_list = []
             if date_events:
                 for occ in date_events:
                     accessor = IEventAccessor(occ)
@@ -260,14 +260,14 @@ class Renderer(base.Renderer):
                     whole_day = accessor.whole_day
                     time = accessor.start.time().strftime('%H:%M')
                     # TODO: make 24/12 hr format configurable
-                    base = u'<a href="%s"><span class="title">%s</span>'\
-                           u'%s%s%s</a>'
-                    events_string += base % (
-                        accessor.url,
-                        accessor.title,
-                        u' %s' % time if not whole_day else u'',
-                        u', ' if not whole_day and location else u'',
-                        u' %s' % location if location else u'')
+                    events_string_list.append(
+                        u'{0}{1}{2}{3}'.format(
+                            accessor.title,
+                            u' {0}'.format(time) if not whole_day else u'',
+                            u', ' if not whole_day and location else u'',
+                            u' {0}'.format(location) if location else u''
+                        )
+                    )
 
             caldata[-1].append(
                 {'date': dat,
@@ -279,7 +279,7 @@ class Renderer(base.Renderer):
                     dat.month == today.month and
                     dat.day == today.day,
                  'date_string': u"%s-%s-%s" % (dat.year, dat.month, dat.day),
-                 'events_string': events_string,
+                 'events_string': u' | '.join(events_string_list),
                  'events': date_events})
         return caldata
 

--- a/plone/app/event/tests/test_portlet_calendar.py
+++ b/plone/app/event/tests/test_portlet_calendar.py
@@ -201,7 +201,7 @@ class RendererTest(unittest.TestCase):
         )
         r.update()
         rd = r.render()
-        self.assertEqual(rd.count('http://nohost/plone/e1'), 3)
+        self.assertEqual(rd.count('e1'), 3)
 
     def test_event_created_last_day_of_month_invalidate_cache(self):
         # First render the calendar portlet when there's no events


### PR DESCRIPTION
https://github.com/plone/Products.CMFPlone/issues/1046 
@thet: afaik,  events_string  is not used anywhere else (?)

![calender](https://cloud.githubusercontent.com/assets/1640384/18229469/c01cfb16-727a-11e6-9844-00d80499b50f.jpg)
