### PR TITLE
Do not index sync_uid, start and end fields if they are empty.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Do not index `sync_uid`, `start` and `end` fields if they are empty.
+  [bsuttor]
 
 
 1.1.7 (2016-09-07)

--- a/plone/app/event/dx/behaviors.py
+++ b/plone/app/event/dx/behaviors.py
@@ -533,7 +533,7 @@ def data_postprocessing(obj, event):
 def start_indexer(obj):
     event = IEventBasic(obj)
     if event.start is None:
-        return None
+        raise AttributeError
     return DT(event.start)
 
 
@@ -542,7 +542,7 @@ def start_indexer(obj):
 def end_indexer(obj):
     event = IEventBasic(obj)
     if event.end is None:
-        return None
+        raise AttributeError
     return DT(event.end)
 
 
@@ -561,7 +561,7 @@ def location_indexer(obj):
 def sync_uid_indexer(obj):
     event = IEventBasic(obj)
     if not event.sync_uid:
-        return None
+        raise AttributeError
     return event.sync_uid
 
 


### PR DESCRIPTION
Do not index sync_uid, start and end fields if they are empty.
With ZCatalog >= 3.1, None index value are not allowed