### PR TITLE
bsuttor cherry picks from 1.1.x into 2.0 branch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ Bug fixes:
 - Fix bug when creating indexes on install. It was not detecting existing
   indexes correctly.
   [vangheem]
+- Update french translations.
+  [bsuttor]
 
 
 2.0.10 (2016-06-06)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,11 +14,15 @@ New features:
 
 Bug fixes:
 
+- Update french translations.
+  [bsuttor]
+
+- Do not index `sync_uid`, `start` and `end` fields if they are empty.
+  [bsuttor]
+
 - Fix bug when creating indexes on install. It was not detecting existing
   indexes correctly.
   [vangheem]
-- Update french translations.
-  [bsuttor]
 
 
 2.0.10 (2016-06-06)

--- a/plone/app/event/dx/behaviors.py
+++ b/plone/app/event/dx/behaviors.py
@@ -310,18 +310,24 @@ if not obj.sync_uid:
 """
 
 
-## Attribute indexer
+# Attribute indexer
 
 # Start indexer
 @indexer(IDXEvent)
 def start_indexer(obj):
-    return IEventAccessor(obj).start
+    start = IEventAccessor(obj).start
+    if not start:
+        raise AttributeError
+    return start
 
 
 # End indexer
 @indexer(IDXEvent)
 def end_indexer(obj):
-    return IEventAccessor(obj).end
+    end = IEventAccessor(obj).end
+    if not end:
+        raise AttributeError
+    return end
 
 
 # Location indexer
@@ -339,7 +345,7 @@ def location_indexer(obj):
 def sync_uid_indexer(obj):
     event = IEventBasic(obj)
     if not event.sync_uid:
-        return None
+        raise AttributeError
     return event.sync_uid
 
 

--- a/plone/app/event/locales/fr/LC_MESSAGES/plone.app.event.po
+++ b/plone/app/event/locales/fr/LC_MESSAGES/plone.app.event.po
@@ -157,12 +157,12 @@ msgstr "Site Internet"
 #. Default: "What"
 #: plone/app/event/browser/event_summary.pt:24
 msgid "event_what"
-msgstr "Quoi"
+msgstr "Quoi ?"
 
 #. Default: "When"
 #: plone/app/event/browser/event_summary.pt:32
 msgid "event_when"
-msgstr "Quand"
+msgstr "Quand ?"
 
 #. Default: "${startdate} to ${enddate}"
 #: plone/app/event/browser/formatted_date.pt:27
@@ -186,7 +186,7 @@ msgstr "${date} à partir de ${starttime}"
 #. Default: "Where"
 #: plone/app/event/browser/event_summary.pt:73
 msgid "event_where"
-msgstr "Ou"
+msgstr "Où ?"
 
 #. Default: "${from} until ${until}."
 #: plone/app/event/browser/event_listing.py:279


### PR DESCRIPTION
- Update french translations.
- Do not index `sync_uid`, `start` and `end` fields if they are empty.