### PR TITLE
 bsuttor cherry picks from 1.1.x into master

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,10 +21,14 @@ Bug fixes:
 - Fix bug when creating indexes on install. It was not detecting existing indexes correctly.
   [vangheem]
 
-- Fixing a typo in dutch translations.
-  [andreesg]
+- Do not index `sync_uid`, `start` and `end` fields if they are empty.
+  [bsuttor]
+
 - Update french translations.
   [bsuttor]
+
+- Fixing a typo in dutch translations.
+  [andreesg]
 
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ Bug fixes:
 
 - Fixing a typo in dutch translations.
   [andreesg]
+- Update french translations.
+  [bsuttor]
 
 
 

--- a/plone/app/event/dx/behaviors.py
+++ b/plone/app/event/dx/behaviors.py
@@ -347,13 +347,19 @@ if not obj.sync_uid:
 # Start indexer
 @indexer(IDXEvent)
 def start_indexer(obj):
-    return IEventAccessor(obj).start
+    start = IEventAccessor(obj).start
+    if not start:
+        raise AttributeError
+    return start
 
 
 # End indexer
 @indexer(IDXEvent)
 def end_indexer(obj):
-    return IEventAccessor(obj).end
+    end = IEventAccessor(obj).end
+    if not end:
+        raise AttributeError
+    return end
 
 
 # Location indexer
@@ -371,7 +377,7 @@ def location_indexer(obj):
 def sync_uid_indexer(obj):
     event = IEventBasic(obj)
     if not event.sync_uid:
-        return None
+        raise AttributeError
     return event.sync_uid
 
 

--- a/plone/app/event/locales/fr/LC_MESSAGES/plone.app.event.po
+++ b/plone/app/event/locales/fr/LC_MESSAGES/plone.app.event.po
@@ -157,12 +157,12 @@ msgstr "Site Internet"
 #. Default: "What"
 #: plone/app/event/browser/event_summary.pt:24
 msgid "event_what"
-msgstr "Quoi"
+msgstr "Quoi ?"
 
 #. Default: "When"
 #: plone/app/event/browser/event_summary.pt:32
 msgid "event_when"
-msgstr "Quand"
+msgstr "Quand ?"
 
 #. Default: "${startdate} to ${enddate}"
 #: plone/app/event/browser/formatted_date.pt:27
@@ -186,7 +186,7 @@ msgstr "${date} à partir de ${starttime}"
 #. Default: "Where"
 #: plone/app/event/browser/event_summary.pt:73
 msgid "event_where"
-msgstr "Ou"
+msgstr "Où ?"
 
 #. Default: "${from} until ${until}."
 #: plone/app/event/browser/event_listing.py:279


### PR DESCRIPTION
- Do not index `sync_uid`, `start` and `end` fields if they are empty.
- Update french translations.