### PR TITLE
expand_events does not remove events

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,11 @@ Changelog
 
 Breaking changes:
 
-- *add item here*
+- #261 expand_events returns the event items passed in `events` even if they do
+  not fit into `start` and `end` (which are only used to limit the search for
+  occurrences).
+  Previously events got removed if they did not fit into the start-end-range although
+  the method is called `*expand*_events`.
 
 New features:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Breaking changes:
   occurrences).
   Previously events got removed if they did not fit into the start-end-range although
   the method is called `*expand*_events`.
+  [fRiSi]
 
 New features:
 

--- a/plone/app/event/base.py
+++ b/plone/app/event/base.py
@@ -283,7 +283,9 @@ def expand_events(events, ret_mode,
         obj = hasattr(it, 'getObject') and it.getObject() or it
         if IEventRecurrence.providedBy(obj):
             occ_set = set(IRecurrenceSupport(obj).occurrences(start, end))
-            occ_set.add(obj)
+            if start is not None:
+                if IEventAccessor(obj).start >= start:
+                    occ_set.add(obj)
             occurrences = [_obj_or_acc(occ, ret_mode) for occ in occ_set]
         elif IEvent.providedBy(obj):
             occurrences = [_obj_or_acc(obj, ret_mode)]

--- a/plone/app/event/base.py
+++ b/plone/app/event/base.py
@@ -227,7 +227,7 @@ def filter_and_resort(context, brains, start, end, sort, sort_reverse):
         _allstarts = sorted(idx['start'])
         _allends = sorted(idx['end'])
         # assuming (start, end) pairs belong together
-        #assert(len(_allstarts) == len(_allends))
+        # assert(len(_allstarts) == len(_allends))
         _occ = itertools.izip(_allstarts, _allends)
         if start:
             _occ = [(s, e) for (s, e) in _occ if e >= _start]
@@ -278,13 +278,13 @@ def expand_events(events, ret_mode,
     :type sort_reverse: boolean
     """
     assert(ret_mode is not RET_MODE_BRAINS)
-
     exp_result = []
     for it in events:
         obj = hasattr(it, 'getObject') and it.getObject() or it
         if IEventRecurrence.providedBy(obj):
-            occurrences = [_obj_or_acc(occ, ret_mode) for occ in
-                           IRecurrenceSupport(obj).occurrences(start, end)]
+            occ_set = set(IRecurrenceSupport(obj).occurrences(start, end))
+            occ_set.add(obj)
+            occurrences = [_obj_or_acc(occ, ret_mode) for occ in occ_set]
         elif IEvent.providedBy(obj):
             occurrences = [_obj_or_acc(obj, ret_mode)]
         else:


### PR DESCRIPTION
now the method really expands events by adding all occurrences (optionally limiting to those that fit into the date range given by `start` and `end`)

previously an event has been removed if it did not fit into this range

(this fixes #261)