### PR TITLE
when traversing to not existend occurence, return a NotFound instead of a site error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Accessing Plone/event/2017-11-29 on an event w/o recurrences no longer
+  raises a StopIteration error [fRiSi]
 
 
 1.1.8 (2016-10-03)

--- a/plone/app/event/recurrence.py
+++ b/plone/app/event/recurrence.py
@@ -111,10 +111,14 @@ class OccurrenceTraverser(DefaultPublishTraverse):
         dateobj = guess_date_from(name, context)
         if dateobj:
             occs = IRecurrenceSupport(context).occurrences(range_start=dateobj)
-            occurrence = occs.next()
-            occ_acc = IEventAccessor(occurrence)
-            if is_same_day(dateobj, occ_acc.start):
-                return occurrence
+            try:
+                occurrence = occs.next()
+                occ_acc = IEventAccessor(occurrence)
+                if is_same_day(dateobj, occ_acc.start):
+                    return occurrence
+            except StopIteration:
+                # if no occurrences are defined, use fallbackTraverse
+                pass
         return self.fallbackTraverse(request, name)
 
     def fallbackTraverse(self, request, name):

--- a/plone/app/event/tests/test_recurrence.py
+++ b/plone/app/event/tests/test_recurrence.py
@@ -48,11 +48,24 @@ class TestTraversalDX(AbstractSampleDataEvents):
     def traverser(self):
         return OccTravDX(self.now_event, self.request)
 
+    @property
+    def traverser_future(self):
+        # event without rrule
+        return OccTravDX(self.future_event, self.request)
+
     def test_no_occurrence(self):
         self.assertRaises(
             AttributeError,
             self.traverser.publishTraverse,
             self.request, 'foo')
+
+    def test_nonexisting_occurrence(self):
+        '''test traversing an occurrence on an event w/o recurrences
+        '''
+        self.assertRaises(
+            AttributeError,
+            self.traverser_future.publishTraverse,
+            self.request, '2017-11-29')
 
     def test_default_views(self):
         view = self.traverser.publishTraverse(self.request, 'event_view')
@@ -113,6 +126,11 @@ class TestTraversalAT(TestTraversalDX):
     @property
     def traverser(self):
         return OccTravAT(self.now_event, self.request)
+
+    @property
+    def traverser_future(self):
+        # event without rrule
+        return OccTravAT(self.future_event, self.request)
 
 
 class TestOccurrences(unittest.TestCase):


### PR DESCRIPTION
currently on an event w/o recurrences accessing Plone/event/2017-11-29 leads to a stopiteration error
visitors get a site-error instead of the notfound page.

add test that for traversing to
* a valid date
* on an event w/o recurrences

to make sure an AttributeError is raised instead of the StopIteration