### PR TITLE
ical fixes, spell_date with optional context

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ Changelog
 
 Breaking changes:
 
+- Introduce ``spell_date`` and deprecate ``date_speller`` in ``plone.app.event.base``.
+  spell_date does only optionally accept an context where date_speller the context was required.
+  [thet]
+
 - Use plone i18n domain.
   [gforcada]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,9 @@ New features:
 
 Bug fixes:
 
+- Fix icalendar export for folderish events which are containers with a ``__getitem__`` method.
+  [thet]
+
 - Python 3 compatibility.
   [pbauer]
 

--- a/plone/app/event/base.py
+++ b/plone/app/event/base.py
@@ -1,15 +1,11 @@
 
 from Acquisition import aq_inner
 from Acquisition import aq_parent
-from DateTime import DateTime
-from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone.i18nl10n import ulocalized_time as orig_ulocalized_time
-from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
-from Products.CMFPlone.utils import safe_callable
 from calendar import monthrange
 from datetime import date
 from datetime import datetime
 from datetime import timedelta
+from DateTime import DateTime
 from persistent.dict import PersistentDict
 from plone.app.event.interfaces import ISO_DATE_FORMAT
 from plone.app.layout.navigation.interfaces import INavigationRoot
@@ -27,11 +23,15 @@ from plone.event.utils import is_same_time
 from plone.event.utils import pydt
 from plone.event.utils import validated_timezone
 from plone.registry.interfaces import IRegistry
+from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.i18nl10n import ulocalized_time as orig_ulocalized_time
+from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
+from Products.CMFPlone.utils import safe_callable
 from zope.annotation.interfaces import IAnnotations
 from zope.component import getUtility
 from zope.component.hooks import getSite
 from zope.component.interfaces import ISite
-
+from zope.deprecation import deprecate
 
 import pytz
 import six
@@ -847,12 +847,20 @@ def dates_for_display(occurrence):
     )
 
 
+@deprecate('date_speller is no longer supported, use spell_date instead.')
 def date_speller(context, dt):
-    """Return a dictionary with localized and readably formatted date parts.
+    return spell_date(dt, context)
+
+
+def spell_date(dt, translation_context=None):
+    """Return a dictionary with localized and readable formatted date parts.
 
     """
+    if not translation_context:
+        translation_context = getSite()
+
     dt = DT(dt)
-    util = getToolByName(context, 'translation_service')
+    util = getToolByName(translation_context, 'translation_service')
     dom = 'plonelocales'
 
     def zero_pad(num):
@@ -865,22 +873,22 @@ def date_speller(context, dt):
         month2=zero_pad(dt.month()),
         month_name=util.translate(
             util.month_msgid(dt.month()),
-            domain=dom, context=context
+            domain=dom, context=translation_context
         ),
         month_abbr=util.translate(
             util.month_msgid(dt.month(), 'a'),
-            domain=dom, context=context
+            domain=dom, context=translation_context
         ),
 
         week=dt.week(),
         wkday=dt.dow(),
         wkday_name=util.translate(
             util.day_msgid(dt.dow()),
-            domain=dom, context=context
+            domain=dom, context=translation_context
         ),
         wkday_abbr=util.translate(
             util.day_msgid(dt.dow(), 's'),
-            domain=dom, context=context
+            domain=dom, context=translation_context
         ),
 
         day=dt.day(),

--- a/plone/app/event/browser/event_listing.py
+++ b/plone/app/event/browser/event_listing.py
@@ -7,7 +7,7 @@ from plone.app.event import _
 from plone.app.event.base import RET_MODE_ACCESSORS
 from plone.app.event.base import RET_MODE_OBJECTS
 from plone.app.event.base import _prepare_range
-from plone.app.event.base import date_speller
+from plone.app.event.base import spell_date
 from plone.app.event.base import expand_events
 from plone.app.event.base import get_events
 from plone.app.event.base import guess_date_from
@@ -246,13 +246,13 @@ class EventListing(BrowserView):
         return provider(occ)
 
     def date_speller(self, date):
-        return date_speller(self.context, date)
+        return spell_date(date, self.context)
 
     @property
     def header_string(self):
         start, end = self._start_end
-        start_dict = date_speller(self.context, start) if start else None
-        end_dict = date_speller(self.context, end) if end else None
+        start_dict = spell_date(start, self.context) if start else None
+        end_dict = spell_date(end, self.context) if end else None
 
         mode = self.mode
         main_msgid = None

--- a/plone/app/event/ical/exporter.py
+++ b/plone/app/event/ical/exporter.py
@@ -165,7 +165,7 @@ def calendar_from_event(context):
     context.
     """
     context = aq_inner(context)
-    return construct_icalendar(context, context)
+    return construct_icalendar(context, [context])
 
 
 @implementer(IICalendar)

--- a/plone/app/event/tests/test_base_module.py
+++ b/plone/app/event/tests/test_base_module.py
@@ -1,32 +1,32 @@
-from DateTime import DateTime
 from datetime import date
 from datetime import datetime
 from datetime import timedelta
+from DateTime import DateTime
 from plone.app.event import base
 from plone.app.event.base import AnnotationAdapter
-from plone.app.event.base import DEFAULT_END_DELTA
-from plone.app.event.base import DT
-from plone.app.event.base import RET_MODE_ACCESSORS
-from plone.app.event.base import RET_MODE_OBJECTS
 from plone.app.event.base import construct_calendar
 from plone.app.event.base import dates_for_display
-from plone.app.event.base import date_speller
 from plone.app.event.base import default_end
+from plone.app.event.base import DEFAULT_END_DELTA
 from plone.app.event.base import default_start
 from plone.app.event.base import default_timezone
+from plone.app.event.base import DT
 from plone.app.event.base import find_context
 from plone.app.event.base import find_event_listing
 from plone.app.event.base import find_ploneroot
 from plone.app.event.base import find_site
 from plone.app.event.base import get_events
 from plone.app.event.base import localized_now
-from plone.app.event.testing import PAEventDX_INTEGRATION_TESTING
+from plone.app.event.base import RET_MODE_ACCESSORS
+from plone.app.event.base import RET_MODE_OBJECTS
+from plone.app.event.base import spell_date
 from plone.app.event.testing import PAEvent_INTEGRATION_TESTING
+from plone.app.event.testing import PAEventDX_INTEGRATION_TESTING
 from plone.app.event.testing import set_env_timezone
 from plone.app.event.testing import set_timezone
 from plone.app.event.tests.base_setup import AbstractSampleDataEvents
-from plone.app.testing import TEST_USER_ID
 from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
 from plone.dexterity.utils import createContentInContainer
 from plone.event.interfaces import IEvent
 from plone.event.interfaces import IEventAccessor
@@ -37,7 +37,6 @@ from zope.annotation.interfaces import IAnnotations
 from zope.component import getUtility
 from zope.component.interfaces import ISite
 from zope.interface import directlyProvides
-
 
 import pytz
 import six
@@ -302,9 +301,9 @@ class TestBaseModule(unittest.TestCase):
             end.hour == 23 and end.minute == 59 and end.second == 59
         )
 
-    def test_date_speller(self):
+    def test_spell_date(self):
         DT = DateTime(2015, 6, 6, 1, 2, 3)
-        date_spelled = date_speller(self.portal, DT)
+        date_spelled = spell_date(DT, self.portal)
         self.assertEqual(date_spelled['year'], 2015)
         self.assertEqual(date_spelled['month'], 6)
         self.assertEqual(date_spelled['month2'], '06')


### PR DESCRIPTION
- Fix icalendar export for folderish events which are containers with a ``__getitem__`` method. 

- Introduce ``spell_date`` and deprecate ``date_speller`` in ``plone.app.event.base``.
  spell_date does only optionally accept an context where date_speller the context was required.
