### PR TITLE
Make sure to include the 'Content-Length' header for ical exports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ New features:
 
 Bug fixes:
 
+- Make sure to include the 'Content-Length' header for ical exports
+  [frapell]
+
 - Update plone.app.event resources. Requires plonetheme.barceloneta >= 1.9.
   [agitator]
 

--- a/plone/app/event/browser/event_listing.py
+++ b/plone/app/event/browser/event_listing.py
@@ -188,12 +188,14 @@ class EventListing(BrowserView):
                              batch=False)
         cal = construct_icalendar(self.context, events)
         name = '%s.ics' % self.context.getId()
+        contents = cal.to_ical()
         self.request.response.setHeader('Content-Type', 'text/calendar')
         self.request.response.setHeader(
             'Content-Disposition',
             'attachment; filename="%s"' % name
         )
-        self.request.response.write(cal.to_ical())
+        self.request.response.setHeader('Content-Length', len(contents))
+        self.request.response.write(contents)
 
     @property
     def ical_url(self):

--- a/plone/app/event/ical/exporter.py
+++ b/plone/app/event/ical/exporter.py
@@ -423,6 +423,6 @@ class EventsICal(BrowserView):
             'Content-Disposition',
             'attachment; filename="{0}"'.format(name)
         )
-        self.request.response.setHeader('Content-Length', len(ical))
         self.request.response.setHeader('Pragma', 'no-cache')
+        self.request.response.setHeader('Content-Length', len(ical))
         self.request.response.write(ical)

--- a/plone/app/event/tests/test_event_listing.py
+++ b/plone/app/event/tests/test_event_listing.py
@@ -49,8 +49,9 @@ class TestEventsListingPortal(AbstractSampleDataEvents):
         headers, output, request = make_fake_response(self.request)
         view = self._listing_view(name='@@event_listing_ical')
         view()
-        self.assertEqual(len(headers), 2)
+        self.assertEqual(len(headers), 3)
         self.assertEqual(headers['Content-Type'], 'text/calendar')
+        self.assertTrue('Content-Length' in headers)
         icalstr = ''.join(output)
         self.assertTrue('Long Event' in icalstr)
 

--- a/plone/app/event/tests/test_icalendar.py
+++ b/plone/app/event/tests/test_icalendar.py
@@ -44,6 +44,7 @@ class ICalendarExportTestDX(AbstractSampleDataEvents):
         view()
         self.assertEqual(len(headers), 4)
         self.assertEqual(headers['Content-Type'], 'text/calendar')
+        self.assertTrue('Content-Length' in headers)
         icalstr = ''.join(output)
 
         self.checkOrder(
@@ -94,6 +95,7 @@ class ICalendarExportTestDX(AbstractSampleDataEvents):
         view()
         self.assertEqual(len(headers), 4)
         self.assertEqual(headers['Content-Type'], 'text/calendar')
+        self.assertTrue('Content-Length' in headers)
         icalstr = ''.join(output)
         self.assertTrue('Now Event' in icalstr)
         self.assertTrue('RRULE' not in icalstr)
@@ -104,6 +106,7 @@ class ICalendarExportTestDX(AbstractSampleDataEvents):
         view()
         self.assertEqual(len(headers), 4)
         self.assertEqual(headers['Content-Type'], 'text/calendar')
+        self.assertTrue('Content-Length' in headers)
         icalstr = ''.join(output)
 
         # No occurrences in export. Otherwise count would be 8.
@@ -195,8 +198,9 @@ class ICalendarExportTestDX(AbstractSampleDataEvents):
         )
         view.mode = 'all'
         view()
-        self.assertEqual(len(headers), 2)
+        self.assertEqual(len(headers), 3)
         self.assertEqual(headers['Content-Type'], 'text/calendar')
+        self.assertTrue('Content-Length' in headers)
         icalstr = ''.join(output)
         # No occurrences in export. Otherwise count would be 8.
         self.assertEqual(icalstr.count('BEGIN:VEVENT'), 4)
@@ -213,8 +217,9 @@ class ICalendarExportTestDX(AbstractSampleDataEvents):
         view.mode = 'day'
         view._date = '2013-04-27'
         view()
-        self.assertEqual(len(headers), 2)
+        self.assertEqual(len(headers), 3)
         self.assertEqual(headers['Content-Type'], 'text/calendar')
+        self.assertTrue('Content-Length' in headers)
         icalstr = ''.join(output)
         self.assertEqual(icalstr.count('BEGIN:VEVENT'), 2)
         self.assertTrue('Past Event' in icalstr)
@@ -231,6 +236,7 @@ class ICalendarExportTestDX(AbstractSampleDataEvents):
         view()
         self.assertEqual(len(headers), 4)
         self.assertEqual(headers['Content-Type'], 'text/calendar')
+        self.assertTrue('Content-Length' in headers)
         icalstr = ''.join(output)
         self.assertEqual(icalstr.count('BEGIN:VEVENT'), 4)
 
@@ -252,6 +258,7 @@ class ICalendarExportTestDX(AbstractSampleDataEvents):
         view()
         self.assertEqual(len(headers), 4)
         self.assertEqual(headers['Content-Type'], 'text/calendar')
+        self.assertTrue('Content-Length' in headers)
         icalstr = ''.join(output)
         self.assertEqual(icalstr.count('BEGIN:VEVENT'), 4)
 


### PR DESCRIPTION
Explicitly set the 'Content-Length' header when exporting events as ICS, to avoid issues like haproxy setting it to 0 under certain configurations