### PR TITLE
Leadimage Viewlet for Event now uses ILeadImageMarker.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,9 @@ Changelog
 
 Breaking changes:
 
-- *add item here*
+- Leadimage Viewlet for Event now uses ILeadImageMarker.
+  (you will need to use plone.app.contenttypes >= 1.4.12)
+  [iham]
 
 New features:
 

--- a/plone/app/event/browser/leadimage_viewlet.py
+++ b/plone/app/event/browser/leadimage_viewlet.py
@@ -1,5 +1,5 @@
 from Acquisition import aq_parent
-from plone.app.contenttypes.behaviors.leadimage import ILeadImage
+from plone.app.contenttypes.behaviors.leadimage import ILeadImageMarker
 from plone.app.layout.viewlets import ViewletBase
 
 
@@ -9,5 +9,5 @@ class LeadImageViewlet(ViewletBase):
     """
     def update(self):
         parent = aq_parent(self.context)
-        self.available = ILeadImage.providedBy(parent) and\
+        self.available = ILeadImageMarker.providedBy(parent) and\
             True if getattr(parent, 'image', False) else False

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages
 import os
 
 
-version = '\.dev0'
+version = '3.1.2.dev0'
 
 
 setup(


### PR DESCRIPTION
this is a follow up fix for [this issue](https://github.com/plone/plone.app.contenttypes/pull/480)