### PR TITLE
Fix missing Content-Length header when exporting iCal

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,15 @@ Changelog
 .. towncrier release notes start
 
 
+1.1.13 (unreleased)
+-------------------
+
+Bug fixes:
+
+- Fix developement buildout
+  [laulaz]
+
+
 1.1.12 (2018-03-07)
 -------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ Changelog
 
 Bug fixes:
 
+- Fix missing Content-Length header when exporting iCal
+  [laulaz]
+
 - Fix developement buildout
   [laulaz]
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -3,6 +3,11 @@ extends =
     https://raw.github.com/collective/buildout.plonetest/master/test-4.3.x.cfg
     https://raw.github.com/collective/buildout.plonetest/master/qa.cfg
 
+extensions =
+    mr.developer
+
+develop = .
+
 package-name = plone.app.event
 package-extras = [test]
 
@@ -11,3 +16,4 @@ parts +=
 
 [versions]
 icalendar = 3.11.3
+plone.app.event =

--- a/plone/app/event/browser/event_listing.py
+++ b/plone/app/event/browser/event_listing.py
@@ -176,13 +176,15 @@ class EventListing(BrowserView):
         events = self.events(ret_mode=RET_MODE_OBJECTS, expand=False,
                              batch=False)
         cal = construct_icalendar(self.context, events)
+        ical = cal.to_ical()
         name = '%s.ics' % self.context.getId()
         self.request.RESPONSE.setHeader('Content-Type', 'text/calendar')
+        self.request.RESPONSE.setHeader('Content-Length', len(ical))
         self.request.RESPONSE.setHeader(
             'Content-Disposition',
             'attachment; filename="%s"' % name
         )
-        self.request.RESPONSE.write(cal.to_ical())
+        self.request.RESPONSE.write(ical)
 
     @property
     def ical_url(self):

--- a/plone/app/event/ical/exporter.py
+++ b/plone/app/event/ical/exporter.py
@@ -298,10 +298,12 @@ class EventsICal(BrowserView):
         return cal.to_ical()
 
     def __call__(self):
+        ical = self.get_ical_string()
         name = '%s.ics' % self.context.getId()
         self.request.RESPONSE.setHeader('Content-Type', 'text/calendar')
         self.request.RESPONSE.setHeader(
             'Content-Disposition',
             'attachment; filename="%s"' % name
         )
-        self.request.RESPONSE.write(self.get_ical_string())
+        self.request.RESPONSE.setHeader('Content-Length', len(ical))
+        self.request.RESPONSE.write(ical)

--- a/plone/app/event/tests/test_event_listing.py
+++ b/plone/app/event/tests/test_event_listing.py
@@ -53,8 +53,9 @@ class TestEventsListingDX(AbstractSampleDataEvents):
         headers, output, request = make_fake_response(self.request)
         view = self.portal.restrictedTraverse('@@event_listing_ical')
         view()
-        self.assertEqual(len(headers), 2)
+        self.assertEqual(len(headers), 3)
         self.assertEqual(headers['Content-Type'], 'text/calendar')
+        self.assertTrue('Content-Length' in headers)
         icalstr = ''.join(output)
         self.assertTrue('Long Event' in icalstr)
 

--- a/plone/app/event/tests/test_icalendar.py
+++ b/plone/app/event/tests/test_icalendar.py
@@ -52,8 +52,9 @@ class ICalendarExportTestDX(AbstractSampleDataEvents):
         headers, output, request = make_fake_response(self.request)
         view = getMultiAdapter((self.now_event, request), name='ics_view')
         view()
-        self.assertEqual(len(headers), 2)
+        self.assertEqual(len(headers), 3)
         self.assertEqual(headers['Content-Type'], 'text/calendar')
+        self.assertTrue('Content-Length' in headers)
         icalstr = ''.join(output)
 
         self.checkOrder(
@@ -103,8 +104,9 @@ class ICalendarExportTestDX(AbstractSampleDataEvents):
         )
         view = getMultiAdapter((occ, request), name='ics_view')
         view()
-        self.assertEqual(len(headers), 2)
+        self.assertEqual(len(headers), 3)
         self.assertEqual(headers['Content-Type'], 'text/calendar')
+        self.assertTrue('Content-Length' in headers)
         icalstr = ''.join(output)
         self.assertTrue('Now Event' in icalstr)
         self.assertTrue('RRULE' not in icalstr)
@@ -113,8 +115,9 @@ class ICalendarExportTestDX(AbstractSampleDataEvents):
         headers, output, request = make_fake_response(self.request)
         view = getMultiAdapter((self.portal, request), name='ics_view')
         view()
-        self.assertEqual(len(headers), 2)
+        self.assertEqual(len(headers), 3)
         self.assertEqual(headers['Content-Type'], 'text/calendar')
+        self.assertTrue('Content-Length' in headers)
         icalstr = ''.join(output)
 
         # No occurrences in export. Otherwise count would be 8.
@@ -207,8 +210,9 @@ class ICalendarExportTestDX(AbstractSampleDataEvents):
         )
         view.mode = 'all'
         view()
-        self.assertEqual(len(headers), 2)
+        self.assertEqual(len(headers), 3)
         self.assertEqual(headers['Content-Type'], 'text/calendar')
+        self.assertTrue('Content-Length' in headers)
         icalstr = ''.join(output)
         # No occurrences in export. Otherwise count would be 8.
         self.assertEqual(icalstr.count('BEGIN:VEVENT'), 4)
@@ -225,8 +229,9 @@ class ICalendarExportTestDX(AbstractSampleDataEvents):
         view.mode = 'day'
         view._date = '2013-04-27'
         view()
-        self.assertEqual(len(headers), 2)
+        self.assertEqual(len(headers), 3)
         self.assertEqual(headers['Content-Type'], 'text/calendar')
+        self.assertTrue('Content-Length' in headers)
         icalstr = ''.join(output)
         self.assertEqual(icalstr.count('BEGIN:VEVENT'), 2)
         self.assertTrue('Past Event' in icalstr)
@@ -241,8 +246,9 @@ class ICalendarExportTestDX(AbstractSampleDataEvents):
             name='ics_view'
         )
         view()
-        self.assertEqual(len(headers), 2)
+        self.assertEqual(len(headers), 3)
         self.assertEqual(headers['Content-Type'], 'text/calendar')
+        self.assertTrue('Content-Length' in headers)
         icalstr = ''.join(output)
         self.assertEqual(icalstr.count('BEGIN:VEVENT'), 4)
 


### PR DESCRIPTION
This causes an empty iCal download when working with Varnish.