### PR TITLE
Load zcml of plone.resource.

### DIFF
--- a/news/2952.bugfix
+++ b/news/2952.bugfix
@@ -1,0 +1,2 @@
+Load zcml of ``plone.resource`` for our use of the ``plone:static`` directive.
+[maurits]

--- a/plone/app/event/configure.zcml
+++ b/plone/app/event/configure.zcml
@@ -9,6 +9,7 @@
   <!-- external dependencies -->
   <include package="plone.browserlayer" />
   <include package="plone.event" />
+  <include package="plone.resource" />
   <include package="plone.formwidget.recurrence" />
   <include package="plone.app.portlets" />
   <include package="plone.app.registry" />


### PR DESCRIPTION
This is for our use of the `plone:static` directive.
See https://github.com/plone/Products.CMFPlone/issues/2952