### PR TITLE
Avoid a deprecation warning

### DIFF
--- a/plone/app/event/__init__.py
+++ b/plone/app/event/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from Products.CMFCore.permissions import setDefaultRoles
+from AccessControl.Permission import addPermission
 from zope.i18nmessageid import MessageFactory
 
 packageName = __name__
@@ -8,7 +8,7 @@ _ = MessageFactory('plone')
 # BBB Permissions
 PORTAL_ADD_PERMISSION = 'Add portal events'  # CMFCalendar/ATCT permissions
 
-setDefaultRoles(
+addPermission(
     PORTAL_ADD_PERMISSION,
     ('Manager', 'Site Administrator', 'Owner',)
 )


### PR DESCRIPTION
It should be safe to not add a fallback, as the commit that introduces this function on AccessControl is more than 10 years old:
https://github.com/zopefoundation/AccessControl/commit/635bd537ab0eacbba9b6a6d2596a8490e16b7203