### PR TITLE
Fix deprecation warnings in tests: use plone.testing.zope and named behaviors.

### DIFF
--- a/news/3130.bugfix
+++ b/news/3130.bugfix
@@ -1,0 +1,2 @@
+Replaced deprecated ``plone.testing.z2`` imports with ``plone.testing.zope``, where possible.
+[maurits]

--- a/plone/app/event/profiles/testing/types/plone.app.event.dx.event.xml
+++ b/plone/app/event/profiles/testing/types/plone.app.event.dx.event.xml
@@ -28,16 +28,16 @@
 
   <!-- Enabled behaviors -->
   <property name="behaviors">
-    <element value="plone.app.event.dx.behaviors.IEventBasic"/>
-    <element value="plone.app.event.dx.behaviors.IEventRecurrence"/>
-    <element value="plone.app.event.dx.behaviors.IEventLocation"/>
-    <element value="plone.app.event.dx.behaviors.IEventAttendees"/>
-    <element value="plone.app.event.dx.behaviors.IEventContact"/>
-    <element value="plone.app.contenttypes.behaviors.richtext.IRichText"/>
-    <element value="plone.app.dexterity.behaviors.metadata.IDublinCore"/>
-    <element value="plone.app.content.interfaces.INameFromTitle"/>
-    <element value="plone.app.dexterity.behaviors.discussion.IAllowDiscussion"/>
-    <element value="plone.app.dexterity.behaviors.exclfromnav.IExcludeFromNavigation"/>
+    <element value="plone.eventbasic"/>
+    <element value="plone.eventrecurrence"/>
+    <element value="plone.eventlocation"/>
+    <element value="plone.eventattendees"/>
+    <element value="plone.eventcontact"/>
+    <element value="plone.richtext"/>
+    <element value="plone.dublincore"/>
+    <element value="plone.namefromtitle"/>
+    <element value="plone.allowdiscussion"/>
+    <element value="plone.excludefromnavigation"/>
   </property>
 
   <!-- View and aliases -->

--- a/plone/app/event/testing.py
+++ b/plone/app/event/testing.py
@@ -6,11 +6,21 @@ from plone.app.testing import IntegrationTesting
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
 from plone.registry.interfaces import IRegistry
-from plone.testing import z2
 from zope.component import getUtility
 from zope.interface import alsoProvides
 
 import os
+
+try:
+    # plone.testing 7+, Plone 5.2+
+    from plone.testing.zope import WSGI_SERVER_FIXTURE
+    from plone.testing.zope import installProduct
+    from plone.testing.zope import uninstallProduct
+except ImportError:
+    # plone.testing 6-, Plone 5.1
+    from plone.testing.z2 import ZSERVER_FIXTURE as WSGI_SERVER_FIXTURE
+    from plone.testing.z2 import installProduct
+    from plone.testing.z2 import uninstallProduct
 
 
 def set_browserlayer(request):
@@ -69,7 +79,7 @@ class PAEventLayer(PloneSandboxLayer):
         self.ostz = os_zone()
 
         # Install products that use an old-style initialize() function
-        z2.installProduct(app, 'Products.DateRecurringIndex')
+        installProduct(app, 'Products.DateRecurringIndex')
 
         # Load ZCML
         import plone.app.event
@@ -81,7 +91,7 @@ class PAEventLayer(PloneSandboxLayer):
 
     def tearDownZope(self, app):
         # Uninstall old-style Products
-        z2.uninstallProduct(app, 'Products.DateRecurringIndex')
+        uninstallProduct(app, 'Products.DateRecurringIndex')
 
         # reset OS TZ
         if self.ostz:
@@ -129,6 +139,6 @@ PAEventDX_ROBOT_TESTING = FunctionalTesting(
     bases=(
         PAEventDX_FIXTURE,
         AUTOLOGIN_LIBRARY_FIXTURE,
-        z2.ZSERVER_FIXTURE,
+        WSGI_SERVER_FIXTURE,
     ),
     name="plone.app.event.dx:Robot")

--- a/plone/app/event/tests/test_dx_behaviors.py
+++ b/plone/app/event/tests/test_dx_behaviors.py
@@ -30,7 +30,6 @@ from plone.event.interfaces import IEvent
 from plone.event.interfaces import IEventAccessor
 from plone.event.interfaces import IOccurrence
 from plone.event.interfaces import IRecurrenceSupport
-from plone.testing.z2 import Browser
 from plone.uuid.interfaces import IUUID
 from zope.annotation.interfaces import IAnnotations
 
@@ -38,6 +37,13 @@ import mock
 import pytz
 import unittest
 import zope.interface
+
+try:
+    # plone.testing 7+
+    from plone.testing.zope import Browser
+except ImportError:
+    # plone.testing 6-
+    from plone.testing.z2 import Browser
 
 
 TEST_TIMEZONE = "Europe/Vienna"

--- a/plone/app/event/tests/test_ical_import.py
+++ b/plone/app/event/tests/test_ical_import.py
@@ -6,10 +6,16 @@ from plone.app.testing import setRoles
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.app.testing import TEST_USER_ID
-from plone.testing.z2 import Browser
 
 import transaction
 import unittest
+
+try:
+    # plone.testing 7+
+    from plone.testing.zope import Browser
+except ImportError:
+    # plone.testing 6-
+    from plone.testing.z2 import Browser
 
 
 class TestICALImportSettings(unittest.TestCase):

--- a/plone/app/event/tests/test_recurrence.py
+++ b/plone/app/event/tests/test_recurrence.py
@@ -22,7 +22,6 @@ from plone.event.interfaces import IEventAccessor
 from plone.event.interfaces import IEventRecurrence
 from plone.event.interfaces import IOccurrence
 from plone.event.interfaces import IRecurrenceSupport
-from plone.testing.z2 import Browser
 from zope.annotation.interfaces import IAnnotations
 from zope.interface import alsoProvides
 from zope.publisher.interfaces.browser import IBrowserView
@@ -34,6 +33,13 @@ import six
 import transaction
 import unittest
 import zope.component
+
+try:
+    # plone.testing 7+
+    from plone.testing.zope import Browser
+except ImportError:
+    # plone.testing 6-
+    from plone.testing.z2 import Browser
 
 
 TZNAME = "Europe/Vienna"


### PR DESCRIPTION
`plone.app.event` master is still used in Plone 5.1, so we fall back to the original `plone.testing.z2` there.
I think named behaviors already work in 5.1.