### PR TITLE
Fix issue with events portlet rendering when thumbs disabled (#332)

### DIFF
--- a/news/332.bugfix
+++ b/news/332.bugfix
@@ -1,0 +1,1 @@
+Fix events portlet error when rendering with thumbnails suppressed [alecpm]

--- a/plone/app/event/portlets/portlet_events.pt
+++ b/plone/app/event/portlets/portlet_events.pt
@@ -29,7 +29,7 @@
             tal:attributes="href item_url;
                             title item_descr"
             tal:define="scale item/context/@@images|nothing;">
-          <span tal:condition="item_hasimage">
+          <span tal:condition="python:thumb_scale and item_hasimage">
               <img tal:define="img_tag python:scale.scale('image', scale=thumb_scale).tag(css_class='pull-right thumb-'+thumb_scale)"
                    tal:replace="structure img_tag" />
           </span>


### PR DESCRIPTION
See #332, plone/plone.app.contenttypes#486, and PR plone/plone.app.contenttypes#603).

This PR is against `3.2.x`, but the commit should merge cleanly against `master` and `3.x`.