### PR TITLE
Do not allow file: protocol in ical url. [3.2.x]

### DIFF
--- a/news/3274.bugfix
+++ b/news/3274.bugfix
@@ -1,0 +1,4 @@
+Do not allow ``file:`` protocol in ical url.
+Previously, only ``file://`` was disallowed, but this left room for relative paths.
+Taken over from `PloneHotfix20210518 <https://plone.org/security/hotfix/20210518/server-side-request-forgery-via-event-ical-url>`_.
+[maurits]

--- a/plone/app/event/ical/importer.py
+++ b/plone/app/event/ical/importer.py
@@ -229,8 +229,8 @@ def no_file_protocol_url(value):
 
     This opens up security issues.
     """
-    if value and value.startswith("file://"):
-        raise Invalid(_(u"URLs with file:// are not allowed."))
+    if value and value.startswith("file:"):
+        raise Invalid(_(u"URLs with file: are not allowed."))
     return True
 
 

--- a/plone/app/event/tests/test_ical_import.py
+++ b/plone/app/event/tests/test_ical_import.py
@@ -73,3 +73,20 @@ class TestICALImportSettings(unittest.TestCase):
         self.assertIn(
             'URL to an external icalendar resource file',
             self.browser.contents)
+
+    def test_constraint(self):
+        self.portal.invokeFactory("Folder", "f1")
+        f1 = self.portal["f1"]
+        f1_url = f1.absolute_url()
+        transaction.commit()
+
+        # Enable ical import.
+        self.browser.open(f1_url + "/ical_import_settings/enable")
+        self.browser.getControl("Confirm action").click()
+
+        # Set it to a file url.
+        self.browser.open(f1_url + "/ical_import_settings")
+        self.assertIn("URL to an external icalendar resource file", self.browser.contents)
+        self.browser.getControl(name="form.widgets.ical_url").value = "file:///tmp/test.ical"
+        self.browser.getControl(name="form.buttons.save").click()
+        self.assertIn("URLs with file: are not allowed.", self.browser.contents)


### PR DESCRIPTION
Previously, only `file://` was disallowed, but this left room for relative paths.
Taken over from [PloneHotfix20210518](https://plone.org/security/hotfix/20210518/server-side-request-forgery-via-event-ical-url).