### PR TITLE
expand_events does not remove events

### DIFF
--- a/news/261.bugfix
+++ b/news/261.bugfix
@@ -1,0 +1,2 @@
+make expand_events return items after start/end limit (fixes https://github.com/plone/plone.app.event/issues/261)
+[fRiSi]

--- a/plone/app/event/base.py
+++ b/plone/app/event/base.py
@@ -279,8 +279,13 @@ def expand_events(events, ret_mode,
     for it in events:
         obj = it.getObject() if getattr(it, 'getObject', False) else it
         if IEventRecurrence.providedBy(obj):
-            occurrences = [_obj_or_acc(occ, ret_mode) for occ in
-                           IRecurrenceSupport(obj).occurrences(start, end)]
+
+            occ_list = list(IRecurrenceSupport(obj).occurrences(start, end))
+            # add original event (to make expand_events not remove one item of the original list)
+            if (start or end) and (IEventAccessor(obj).start >= (end or start)):
+                if obj not in occ_list:
+                    occ_list.append(obj)
+            occurrences = [_obj_or_acc(occ, ret_mode) for occ in occ_list]
         elif IEvent.providedBy(obj):
             occurrences = [_obj_or_acc(obj, ret_mode)]
         else:


### PR DESCRIPTION
expand_events returns the event items passed in `events` even if they do not fit into `start` and `end` (which are only used to limit the search for occurrences).

Previously events got removed if they did not fit into the start-end-range although the method is called `*expand*_events`.

(this fixes #261)