### PR TITLE
JavaScript improvements

### DIFF
--- a/news/355-2.bugfix
+++ b/news/355-2.bugfix
@@ -1,0 +1,2 @@
+Remove project-specific code from selectors in the event JavaScript.
+[thet]

--- a/news/355-3.bugfix
+++ b/news/355-3.bugfix
@@ -1,0 +1,1 @@
+Do frontend date widget calculation with datetime-native dates to simplify code better universal support.

--- a/news/355.bugfix
+++ b/news/355.bugfix
@@ -1,0 +1,2 @@
+Wrap JavaScript a immediately invoked function to not expose the functions in global namespace.
+[thet]

--- a/plone/app/event/browser/resources/event.js
+++ b/plone/app/event/browser/resources/event.js
@@ -1,5 +1,4 @@
 (function () {
-
   function is_valid_date(date) {
     // https://stackoverflow.com/a/1353711/1337474
     return date instanceof Date && !isNaN(date);
@@ -38,7 +37,11 @@
     }
   }
 
-  function whole_day_toggle(event_edit__whole_day, event_edit__start, event_edit__end) {
+  function whole_day_toggle(
+    event_edit__whole_day,
+    event_edit__start,
+    event_edit__end
+  ) {
     start_val = event_edit__start.value;
     end_val = event_edit__end.value;
     if (event_edit__whole_day.checked) {
@@ -50,16 +53,15 @@
     }
     // set start/end values with current hours when switching back to
     // datetime-local
-    if(start_val.indexOf("T") == -1) {
-      start_val = `${start_val}T${(new Date()).getHours()}:00`;
-      end_val = `${end_val}T${(new Date()).getHours() + 1}:00`;
+    if (start_val.indexOf("T") == -1) {
+      start_val = `${start_val}T${new Date().getHours()}:00`;
+      end_val = `${end_val}T${new Date().getHours() + 1}:00`;
     }
     set_date(event_edit__start, start_val);
     set_date(event_edit__end, end_val);
   }
 
-  document.addEventListener("DOMContentLoaded", function() {
-
+  document.addEventListener("DOMContentLoaded", function () {
     var event_edit__open_end = document.querySelector("input[name='form.widgets.IEventBasic.open_end:list']"); // prettier-ignore
     var event_edit__whole_day = document.querySelector("input[name='form.widgets.IEventBasic.whole_day:list']"); // prettier-ignore
     var event_edit__start = document.querySelector("[name='form.widgets.IEventBasic.start']"); // prettier-ignore
@@ -85,19 +87,26 @@
 
     if (event_edit__open_end) {
       open_end_toggle(event_edit__open_end, event_edit__end);
-      event_edit__open_end.addEventListener("input", function() {
+      event_edit__open_end.addEventListener("input", function () {
         open_end_toggle(event_edit__open_end, event_edit__end);
       });
     }
 
     if (event_edit__whole_day) {
       // on load
-      whole_day_toggle(event_edit__whole_day, event_edit__start, event_edit__end);
+      whole_day_toggle(
+        event_edit__whole_day,
+        event_edit__start,
+        event_edit__end
+      );
       // on change
-      event_edit__whole_day.addEventListener("input", function(e) {
-        whole_day_toggle(event_edit__whole_day, event_edit__start, event_edit__end);
+      event_edit__whole_day.addEventListener("input", function (e) {
+        whole_day_toggle(
+          event_edit__whole_day,
+          event_edit__start,
+          event_edit__end
+        );
       });
     }
   });
-
 })();

--- a/plone/app/event/browser/resources/event.js
+++ b/plone/app/event/browser/resources/event.js
@@ -1,19 +1,39 @@
 (function () {
+  function zero_pad(val, len) {
+    val = val.toString();
+    len = len || 2;
+    while (val.length < len) {
+      val = "0" + val;
+    }
+    return val;
+  }
+
+  function datetime_local_iso(date) {
+    // Return the current date/time as timezone naive ISO string.
+    return (
+      zero_pad(date.getFullYear()) +
+      "-" +
+      zero_pad(date.getMonth() + 1) +
+      "-" +
+      zero_pad(date.getDate()) +
+      "T" +
+      zero_pad(date.getHours()) +
+      ":" +
+      zero_pad(date.getMinutes())
+    );
+  }
+
   function is_valid_date(date) {
     // https://stackoverflow.com/a/1353711/1337474
     return date instanceof Date && !isNaN(date);
   }
 
-  function tzaware_date(date) {
-    tzoffset = -date.getTimezoneOffset() * 60 * 1000;
-    date.setTime(date.getTime() + tzoffset);
-    return date;
-  }
-
   function add_hours(date, hours) {
     // https://stackoverflow.com/a/1050782/1337474
+    hours = hours || 1;
     date.setTime(date.getTime() + hours * 60 * 60 * 1000);
-    return date;
+    var iso = datetime_local_iso(date);
+    return new Date(iso);
   }
 
   function set_date(el, datevalue) {
@@ -21,11 +41,11 @@
     if (!is_valid_date(date)) {
       return;
     }
-    isostring = tzaware_date(date).toISOString();
+    isostring = datetime_local_iso(date);
     if (el.type === "date") {
       el.value = isostring.split("T")[0];
     } else if (el.type === "datetime-local") {
-      el.value = isostring.split(".")[0];
+      el.value = isostring;
     }
   }
 
@@ -51,12 +71,6 @@
       event_edit__start.type = "datetime-local";
       event_edit__end.type = "datetime-local";
     }
-    // set start/end values with current hours when switching back to
-    // datetime-local
-    if (start_val.indexOf("T") == -1) {
-      start_val = `${start_val}T${new Date().getHours()}:00`;
-      end_val = `${end_val}T${new Date().getHours() + 1}:00`;
-    }
     set_date(event_edit__start, start_val);
     set_date(event_edit__end, end_val);
   }
@@ -79,8 +93,7 @@
         if (!is_valid_date(_end) || _end < _start) {
           _end = _start;
           _end = add_hours(_end, 1);
-          end_val = _end.toISOString();
-          set_date(event_edit__end, end_val);
+          set_date(event_edit__end, _end);
         }
       });
     }

--- a/plone/app/event/browser/resources/event.js
+++ b/plone/app/event/browser/resources/event.js
@@ -60,10 +60,10 @@
 
   document.addEventListener("DOMContentLoaded", function() {
 
-    var event_edit__open_end = document.querySelector("input[name='form.widgets.IEventBasic.open_end:list'], input[name='form.widgets.IEventBasicNonRequired.open_end:list']"); // prettier-ignore
-    var event_edit__whole_day = document.querySelector("input[name='form.widgets.IEventBasic.whole_day:list'], input[name='form.widgets.IEventBasicNonRequired.whole_day:list']"); // prettier-ignore
-    var event_edit__start = document.querySelector("[name='form.widgets.IEventBasic.start'], [name='form.widgets.IEventBasicNonRequired.start']"); // prettier-ignore
-    var event_edit__end = document.querySelector("[name='form.widgets.IEventBasic.end'], [name='form.widgets.IEventBasicNonRequired.end']"); // prettier-ignore
+    var event_edit__open_end = document.querySelector("input[name='form.widgets.IEventBasic.open_end:list']"); // prettier-ignore
+    var event_edit__whole_day = document.querySelector("input[name='form.widgets.IEventBasic.whole_day:list']"); // prettier-ignore
+    var event_edit__start = document.querySelector("[name='form.widgets.IEventBasic.start']"); // prettier-ignore
+    var event_edit__end = document.querySelector("[name='form.widgets.IEventBasic.end']"); // prettier-ignore
 
     var start_val;
     var end_val;

--- a/plone/app/event/browser/resources/event.js
+++ b/plone/app/event/browser/resources/event.js
@@ -1,99 +1,103 @@
-function is_valid_date(date) {
-  // https://stackoverflow.com/a/1353711/1337474
-  return date instanceof Date && !isNaN(date);
-}
+(function () {
 
-function tzaware_date(date) {
-  tzoffset = -date.getTimezoneOffset() * 60 * 1000;
-  date.setTime(date.getTime() + tzoffset);
-  return date;
-}
-
-function add_hours(date, hours) {
-  // https://stackoverflow.com/a/1050782/1337474
-  date.setTime(date.getTime() + hours * 60 * 60 * 1000);
-  return date;
-}
-
-function set_date(el, datevalue) {
-  var date = new Date(datevalue); // change to Date to enforce datetime isostrings.
-  if (!is_valid_date(date)) {
-    return;
-  }
-  isostring = tzaware_date(date).toISOString();
-  if (el.type === "date") {
-    el.value = isostring.split("T")[0];
-  } else if (el.type === "datetime-local") {
-    el.value = isostring.split(".")[0];
-  }
-}
-
-function open_end_toggle(event_edit__open_end, event_edit__end) {
-  if (event_edit__open_end.checked) {
-    $(event_edit__end.closest(".field")).hide();
-  } else {
-    $(event_edit__end.closest(".field")).show();
-  }
-}
-
-function whole_day_toggle(event_edit__whole_day, event_edit__start, event_edit__end) {
-  start_val = event_edit__start.value;
-  end_val = event_edit__end.value;
-  if (event_edit__whole_day.checked) {
-    event_edit__start.type = "date";
-    event_edit__end.type = "date";
-  } else {
-    event_edit__start.type = "datetime-local";
-    event_edit__end.type = "datetime-local";
-  }
-  // set start/end values with current hours when switching back to
-  // datetime-local
-  if(start_val.indexOf("T") == -1) {
-    start_val = `${start_val}T${(new Date()).getHours()}:00`;
-    end_val = `${end_val}T${(new Date()).getHours() + 1}:00`;
-  }
-  set_date(event_edit__start, start_val);
-  set_date(event_edit__end, end_val);
-}
-
-document.addEventListener("DOMContentLoaded", function() {
-
-  var event_edit__open_end = document.querySelector("input[name='form.widgets.IEventBasic.open_end:list'], input[name='form.widgets.IEventBasicNonRequired.open_end:list']"); // prettier-ignore
-  var event_edit__whole_day = document.querySelector("input[name='form.widgets.IEventBasic.whole_day:list'], input[name='form.widgets.IEventBasicNonRequired.whole_day:list']"); // prettier-ignore
-  var event_edit__start = document.querySelector("[name='form.widgets.IEventBasic.start'], [name='form.widgets.IEventBasicNonRequired.start']"); // prettier-ignore
-  var event_edit__end = document.querySelector("[name='form.widgets.IEventBasic.end'], [name='form.widgets.IEventBasicNonRequired.end']"); // prettier-ignore
-
-  var start_val;
-  var end_val;
-
-  if (event_edit__start) {
-    event_edit__start.addEventListener("change", function () {
-      start_val = event_edit__start.value;
-      end_val = event_edit__end.value;
-      var _start = new Date(start_val);
-      var _end = new Date(end_val);
-      if (!is_valid_date(_end) || _end < _start) {
-        _end = _start;
-        _end = add_hours(_end, 1);
-        end_val = _end.toISOString();
-        set_date(event_edit__end, end_val);
-      }
-    });
+  function is_valid_date(date) {
+    // https://stackoverflow.com/a/1353711/1337474
+    return date instanceof Date && !isNaN(date);
   }
 
-  if (event_edit__open_end) {
-    open_end_toggle(event_edit__open_end, event_edit__end);
-    event_edit__open_end.addEventListener("input", function() {
+  function tzaware_date(date) {
+    tzoffset = -date.getTimezoneOffset() * 60 * 1000;
+    date.setTime(date.getTime() + tzoffset);
+    return date;
+  }
+
+  function add_hours(date, hours) {
+    // https://stackoverflow.com/a/1050782/1337474
+    date.setTime(date.getTime() + hours * 60 * 60 * 1000);
+    return date;
+  }
+
+  function set_date(el, datevalue) {
+    var date = new Date(datevalue); // change to Date to enforce datetime isostrings.
+    if (!is_valid_date(date)) {
+      return;
+    }
+    isostring = tzaware_date(date).toISOString();
+    if (el.type === "date") {
+      el.value = isostring.split("T")[0];
+    } else if (el.type === "datetime-local") {
+      el.value = isostring.split(".")[0];
+    }
+  }
+
+  function open_end_toggle(event_edit__open_end, event_edit__end) {
+    if (event_edit__open_end.checked) {
+      $(event_edit__end.closest(".field")).hide();
+    } else {
+      $(event_edit__end.closest(".field")).show();
+    }
+  }
+
+  function whole_day_toggle(event_edit__whole_day, event_edit__start, event_edit__end) {
+    start_val = event_edit__start.value;
+    end_val = event_edit__end.value;
+    if (event_edit__whole_day.checked) {
+      event_edit__start.type = "date";
+      event_edit__end.type = "date";
+    } else {
+      event_edit__start.type = "datetime-local";
+      event_edit__end.type = "datetime-local";
+    }
+    // set start/end values with current hours when switching back to
+    // datetime-local
+    if(start_val.indexOf("T") == -1) {
+      start_val = `${start_val}T${(new Date()).getHours()}:00`;
+      end_val = `${end_val}T${(new Date()).getHours() + 1}:00`;
+    }
+    set_date(event_edit__start, start_val);
+    set_date(event_edit__end, end_val);
+  }
+
+  document.addEventListener("DOMContentLoaded", function() {
+
+    var event_edit__open_end = document.querySelector("input[name='form.widgets.IEventBasic.open_end:list'], input[name='form.widgets.IEventBasicNonRequired.open_end:list']"); // prettier-ignore
+    var event_edit__whole_day = document.querySelector("input[name='form.widgets.IEventBasic.whole_day:list'], input[name='form.widgets.IEventBasicNonRequired.whole_day:list']"); // prettier-ignore
+    var event_edit__start = document.querySelector("[name='form.widgets.IEventBasic.start'], [name='form.widgets.IEventBasicNonRequired.start']"); // prettier-ignore
+    var event_edit__end = document.querySelector("[name='form.widgets.IEventBasic.end'], [name='form.widgets.IEventBasicNonRequired.end']"); // prettier-ignore
+
+    var start_val;
+    var end_val;
+
+    if (event_edit__start) {
+      event_edit__start.addEventListener("change", function () {
+        start_val = event_edit__start.value;
+        end_val = event_edit__end.value;
+        var _start = new Date(start_val);
+        var _end = new Date(end_val);
+        if (!is_valid_date(_end) || _end < _start) {
+          _end = _start;
+          _end = add_hours(_end, 1);
+          end_val = _end.toISOString();
+          set_date(event_edit__end, end_val);
+        }
+      });
+    }
+
+    if (event_edit__open_end) {
       open_end_toggle(event_edit__open_end, event_edit__end);
-    });
-  }
+      event_edit__open_end.addEventListener("input", function() {
+        open_end_toggle(event_edit__open_end, event_edit__end);
+      });
+    }
 
-  if (event_edit__whole_day) {
-    // on load
-    whole_day_toggle(event_edit__whole_day, event_edit__start, event_edit__end);
-    // on change
-    event_edit__whole_day.addEventListener("input", function(e) {
+    if (event_edit__whole_day) {
+      // on load
       whole_day_toggle(event_edit__whole_day, event_edit__start, event_edit__end);
-    });
-  }
-});
+      // on change
+      event_edit__whole_day.addEventListener("input", function(e) {
+        whole_day_toggle(event_edit__whole_day, event_edit__start, event_edit__end);
+      });
+    }
+  });
+
+})();


### PR DESCRIPTION
- Wrap JavaScript a immediately invoked function to not expose the functions in global namespace.
- Remove project-specific code from selectors in the event JavaScript.
- Do frontend date widget calculation with datetime-native dates to simplify code better universal support.


@petschki I used the plone.app.event script with your additions in a own project, but setting the end date based on the start date did not really work. Maybe I did integrate it incorrectly late at night, but in the end this is what I came up with. I think this is a simpler approach as it does not mess with timezones where we do explicitly not want timezones (datetime-native).