### PR TITLE
Remove dependency on plone.app.multilingual.

### DIFF
--- a/news/367-pam.breaking
+++ b/news/367-pam.breaking
@@ -1,0 +1,2 @@
+Breaking dependency cleanup: Move declaration of language independence of on IEventBasic fields to plone.app.multilingual.
+[jensens]

--- a/plone/app/event/dx/behaviors.py
+++ b/plone/app/event/dx/behaviors.py
@@ -13,7 +13,6 @@ from plone.app.event.base import localized_now
 from plone.app.event.base import wkday_to_mon1
 from plone.app.event.dx.interfaces import IDXEvent
 from plone.app.event.dx.interfaces import IDXEventRecurrence
-from plone.app.multilingual.dx.interfaces import ILanguageIndependentField
 from plone.app.textfield.value import RichTextValue
 from plone.app.z3cform.widget import DatetimeFieldWidget
 from plone.autoform import directives
@@ -237,14 +236,8 @@ alsoProvides(IEventAttendees, IFormFieldProvider)
 alsoProvides(IEventContact, IFormFieldProvider)
 
 
-# Language independent fields
-alsoProvides(IEventBasic["start"], ILanguageIndependentField)
-alsoProvides(IEventBasic["end"], ILanguageIndependentField)
-alsoProvides(IEventBasic["whole_day"], ILanguageIndependentField)
-alsoProvides(IEventBasic["open_end"], ILanguageIndependentField)
-
-
 # Attribute indexer
+
 
 # Start indexer
 @indexer(IDXEvent)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 import os
 
 
-version = "4.0.1.dev0"
+version = "5.0.0.dev0"
 
 
 long_description = "\n\n".join(
@@ -51,7 +51,6 @@ setup(
         "plone.app.contentlisting",
         "plone.app.dexterity",
         "plone.app.layout",
-        "plone.app.multilingual",
         "plone.app.portlets >= 2.5.1",
         "plone.app.querystring",
         "plone.app.registry",


### PR DESCRIPTION
The plone.app.event IEventBasic fields are language independent. 
Move code to plone.app.multilingual to not depend on it.

Needs test/merge together with plone/plone.app.multilingual#414