### PR TITLE
Event Occurrence `open_end` fix

### DIFF
--- a/news/362.bugfix
+++ b/news/362.bugfix
@@ -1,2 +1,2 @@
-Fix `open_end` Event Occurrence display.
-[petschki]
+Fix date display for recurring `open_end` events and multi day `whole_day` events by correcting duration.
+[ksuess, petschki]

--- a/news/362.bugfix
+++ b/news/362.bugfix
@@ -1,0 +1,2 @@
+Fix `open_end` Event Occurrence display.
+[petschki]

--- a/plone/app/event/recurrence.py
+++ b/plone/app/event/recurrence.py
@@ -61,8 +61,10 @@ class RecurrenceSupport:
         # We get event ends by adding a duration to the start. This way, we
         # prevent that the start and end lists are of different size if an
         # event starts before range_start but ends afterwards.
-        if getattr(event, "whole_day", None) or getattr(event, "open_end", None):
+        if getattr(event, "open_end", None):
             event_end = dt_end_of_day(event_start)
+        elif getattr(event, "whole_day", None):
+            event_end = dt_end_of_day(getattr(self.context, "end", None))
         else:
             event_end = getattr(self.context, "end", None)
 

--- a/plone/app/event/recurrence.py
+++ b/plone/app/event/recurrence.py
@@ -1,5 +1,6 @@
 from Acquisition import aq_parent
 from OFS.SimpleItem import SimpleItem
+from plone.app.event.base import dt_end_of_day
 from plone.app.event.base import dt_start_of_day
 from plone.app.event.base import guess_date_from
 from plone.base.utils import safe_text
@@ -17,8 +18,6 @@ from zope.component import adapter
 from zope.interface import implementer
 from zope.publisher.interfaces.browser import IBrowserRequest
 from ZPublisher.BaseRequest import DefaultPublishTraverse
-
-import datetime
 
 
 @adapter(IEventRecurrence)
@@ -63,10 +62,11 @@ class RecurrenceSupport:
         # prevent that the start and end lists are of different size if an
         # event starts before range_start but ends afterwards.
         if getattr(event, "whole_day", None) or getattr(event, "open_end", None):
-            duration = datetime.timedelta(hours=23, minutes=59, seconds=59)
+            event_end = dt_end_of_day(event_start)
         else:
             event_end = getattr(self.context, "end", None)
-            duration = event_end - event_start
+
+        duration = event_end - event_start
 
         starts = recurrence_sequence_ical(
             event_start,


### PR DESCRIPTION
fixes #362 

screenshots with debug info `date_dict/iso_start - date_dict/iso_end`

Before:
<img width="600" alt="Bildschirm­foto 2023-03-30 um 08 12 01" src="https://user-images.githubusercontent.com/511761/228747225-5f72c382-3702-441c-93c6-7228a7bb5a41.png">

After:
<img width="592" alt="Bildschirm­foto 2023-03-30 um 08 12 21" src="https://user-images.githubusercontent.com/511761/228747262-c6db09b1-1f9b-4a7c-96a2-48f9d395af31.png">
