### PR TITLE
Fix test_long_event when run around midnight of first day of month

### DIFF
--- a/news/334.tests
+++ b/news/334.tests
@@ -1,0 +1,3 @@
+Fix test_long_event when run around midnight of the first day of the month.
+Fixes `issue 334 <https://github.com/plone/plone.app.event/issues/334>`_.
+[maurits]


### PR DESCRIPTION
Fixes https://github.com/plone/plone.app.event/issues/334.

Screen shot of the rendered portlet (no css here) in the new test:

![Screenshot 2023-09-01 at 18 39 10](https://github.com/plone/plone.app.event/assets/210587/47304deb-679e-4cbe-8069-9d18a862bb8b)
