### PR TITLE
Require setuptools 68.2 or higher for building the package.

### DIFF
--- a/news/172.internal
+++ b/news/172.internal
@@ -1,0 +1,5 @@
+Require setuptools 68.2 or higher for building the package.
+When built with setuptools 68.1, you could not import the package, at least not an editable package.
+Note that you can still *install* this package with older setuptools versions.
+See `Plone meta issue 172 <https://github.com/plone/meta/issues/172>`_ for details.
+[maurits]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 # Generated from:
 # https://github.com/plone/meta/tree/master/config/default
 # See the inline comments on how to expand/tweak this configuration file
+[build-system]
+requires = ["setuptools>=68.2", "wheel"]
+
 [tool.towncrier]
 directory = "news/"
 filename = "CHANGES.rst"

--- a/tox.ini
+++ b/tox.ini
@@ -125,7 +125,7 @@ commands =
     # we build the change log as news entries might break
     # the README that is displayed on PyPI
     towncrier build --version=100.0.0 --yes
-    python -m build --sdist --no-isolation
+    python -m build --sdist
     twine check dist/*
 
 [testenv:circular]

--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,7 @@ deps =
     build
     z3c.dependencychecker==2.11
 commands =
-    python -m build --sdist --no-isolation
+    python -m build --sdist
     dependencychecker
 
 [testenv:dependencies-graph]


### PR DESCRIPTION
When built with setuptools 68.1, you could not import the package, at least not an editable package. Note that you can still *install* this package with older setuptools versions. See [Plone meta issue 172](https://github.com/plone/meta/issues/172) for details.

New problem though.  `tox -e dependencies` says:

```
ERROR Missing dependencies:
	setuptools>=68.2
```

I tried with `setuptools<68.1', which would also work, but that only changes the message:

```
ERROR Missing dependencies:
	setuptools<68.1
```

I think this is a shortcoming in `z3c.dependencychecker`.  It should not report this as a missing dependency. It should see that `pyproject.toml` has this dependency covered.

We definitely should *not* require `setuptools>=68.2` in `install_requires`.