### PR TITLE
Conditionally load the zcml for our portlets.

### DIFF
--- a/news/3923.bugfix
+++ b/news/3923.bugfix
@@ -1,0 +1,2 @@
+Conditionally load the zcml for our portlets.
+[maurits]

--- a/plone/app/event/configure.zcml
+++ b/plone/app/event/configure.zcml
@@ -12,7 +12,6 @@
   <include package="plone.event" />
   <include package="plone.resource" />
   <include package="plone.formwidget.recurrence" />
-  <include package="plone.app.portlets" />
   <include package="plone.app.registry" />
   <include package="plone.app.z3cform" />
 
@@ -20,11 +19,16 @@
   <include file="permissions.zcml" />
   <include package=".dx" />
   <include package=".browser" />
-  <include package=".portlets" />
   <include package=".ical" />
   <include file="recurrence.zcml" />
   <include package=".upgrades" />
 
+  <configure zcml:condition="not-have disable-classic-ui">
+    <configure zcml:condition="installed plone.app.portlets">
+      <include package="plone.app.portlets" />
+      <include package=".portlets" />
+    </configure>
+  </configure>
   <utility
       name="plone.app.event.SynchronizationStrategies"
       component=".vocabularies.SynchronizationStrategies"


### PR DESCRIPTION
Only load them when plone.app.portlets is available and Classic UI is wanted. This is the default in Plone 6, but may be switched off in 6.1. In Plone 7 this won't be the default.

See https://github.com/plone/Products.CMFPlone/issues/3923

This uses the zcml feature that is introduced in https://github.com/plone/Products.CMFPlone/pull/3922, but it can be merged independently: if the zcml feature is not available, the portlet zcml is loaded just like before.