### PR TITLE
Fix for #387 - Fix calculation of eventaccessor urls

### DIFF
--- a/news/387.bugfix.md
+++ b/news/387.bugfix.md
@@ -1,0 +1,1 @@
+Fix calculation of eventaccessor urls @1letter

--- a/plone/app/event/dx/behaviors.py
+++ b/plone/app/event/dx/behaviors.py
@@ -32,7 +32,6 @@ from z3c.form.browser.text import TextFieldWidget
 from z3c.form.browser.textlines import TextLinesFieldWidget
 from zope import schema
 from zope.component import adapter
-from zope.component.hooks import getSite
 from zope.globalrequest import getRequest
 from zope.interface import alsoProvides
 from zope.interface import implementer
@@ -340,23 +339,12 @@ class EventAccessor:
 
     @property
     def url(self):
-        """calculate the path, is required as long the ram.cache is active in portlets renderer
-        the return value of self.context.absolute_url() differs
-        with ram cache: portal/testtermin
-        without ram cache: http://site.local/testevent
+        """need to lookup globalrequest in order to calculate
+        correct URL during cached lookup (eg. in event portlet renderer)
         """
-
-        portal = getSite()
-        portal_url = portal.absolute_url()
-        portal_path = list(portal.getPhysicalPath())
-        event_path = list(self.context.getPhysicalPath())
-        path_without_portal = ""
-        if len(portal_path) > 0:
-            path_without_portal = "/".join(event_path[len(portal_path) :])
-
-        url = f"{portal_url}/{path_without_portal}"
-
-        return safe_text(url)
+        request = getRequest()
+        absolute_url = request.physicalPathToURL(self.context.getPhysicalPath())
+        return absolute_url
 
     @property
     def created(self):

--- a/plone/app/event/dx/behaviors.py
+++ b/plone/app/event/dx/behaviors.py
@@ -1,6 +1,7 @@
 """Behaviors to enable calendarish event extension to dexterity content types.
 """
 
+from plone import api
 from plone.app.dexterity.behaviors.metadata import ICategorization
 from plone.app.event import _
 from plone.app.event.base import default_end as default_end_dt
@@ -339,7 +340,21 @@ class EventAccessor:
 
     @property
     def url(self):
-        return safe_text(self.context.absolute_url())
+        """calculate the path, is required as long the ram.cache is activ in portlets renderer
+        the return value of self.context.absolute_url() differs
+        with ram cache: portal/testtermin
+        without ram cache: http://site.local/testevent
+        """
+        portal_url = api.portal.get().absolute_url()
+        portal_path = list(api.portal.get().getPhysicalPath())
+        event_path = list(self.context.getPhysicalPath())
+        path_without_portal = ""
+        if len(portal_path) > 0:
+            path_without_portal = "/".join(event_path[len(portal_path) :])
+
+        url = f"{portal_url}/{path_without_portal}"
+
+        return safe_text(url)
 
     @property
     def created(self):

--- a/plone/app/event/dx/behaviors.py
+++ b/plone/app/event/dx/behaviors.py
@@ -32,6 +32,7 @@ from z3c.form.browser.text import TextFieldWidget
 from z3c.form.browser.textlines import TextLinesFieldWidget
 from zope import schema
 from zope.component import adapter
+from zope.component.hooks import getSite
 from zope.globalrequest import getRequest
 from zope.interface import alsoProvides
 from zope.interface import implementer
@@ -39,7 +40,6 @@ from zope.interface import Invalid
 from zope.interface import invariant
 from zope.interface import provider
 from zope.schema.interfaces import IContextAwareDefaultFactory
-from zope.component.hooks import getSite
 
 
 def first_weekday_sun0():

--- a/plone/app/event/dx/behaviors.py
+++ b/plone/app/event/dx/behaviors.py
@@ -340,7 +340,7 @@ class EventAccessor:
 
     @property
     def url(self):
-        """calculate the path, is required as long the ram.cache is activ in portlets renderer
+        """calculate the path, is required as long the ram.cache is active in portlets renderer
         the return value of self.context.absolute_url() differs
         with ram cache: portal/testtermin
         without ram cache: http://site.local/testevent

--- a/plone/app/event/dx/behaviors.py
+++ b/plone/app/event/dx/behaviors.py
@@ -1,7 +1,6 @@
 """Behaviors to enable calendarish event extension to dexterity content types.
 """
 
-from plone import api
 from plone.app.dexterity.behaviors.metadata import ICategorization
 from plone.app.event import _
 from plone.app.event.base import default_end as default_end_dt
@@ -40,6 +39,7 @@ from zope.interface import Invalid
 from zope.interface import invariant
 from zope.interface import provider
 from zope.schema.interfaces import IContextAwareDefaultFactory
+from zope.component.hooks import getSite
 
 
 def first_weekday_sun0():
@@ -345,8 +345,10 @@ class EventAccessor:
         with ram cache: portal/testtermin
         without ram cache: http://site.local/testevent
         """
-        portal_url = api.portal.get().absolute_url()
-        portal_path = list(api.portal.get().getPhysicalPath())
+
+        portal = getSite()
+        portal_url = portal.absolute_url()
+        portal_path = list(portal.getPhysicalPath())
         event_path = list(self.context.getPhysicalPath())
         path_without_portal = ""
         if len(portal_path) > 0:

--- a/plone/app/event/tests/base_setup.py
+++ b/plone/app/event/tests/base_setup.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from datetime import timedelta
+from dateutil.relativedelta import relativedelta
 from plone.app.event.dx import behaviors
 from plone.app.event.testing import set_browserlayer
 from plone.app.event.testing import set_timezone
@@ -45,8 +46,9 @@ class AbstractSampleDataEvents(unittest.TestCase):
         past = self.past = tz.normalize(now - timedelta(days=10))
         future = self.future = tz.normalize(now + timedelta(days=10))
         far = self.far = tz.normalize(now + timedelta(days=30))
+        scifi = self.scifi = tz.normalize(now + relativedelta(years=50))
         duration = self.duration = timedelta(hours=1)
-        return (now, past, future, far, duration)
+        return (now, past, future, far, duration, scifi)
 
     def setUp(self):
         """Construct sample contents.
@@ -72,7 +74,7 @@ class AbstractSampleDataEvents(unittest.TestCase):
         set_browserlayer(self.request)
         set_timezone(TEST_TIMEZONE)
 
-        now, past, future, far, duration = self.make_dates()
+        now, past, future, far, duration, scifi = self.make_dates()
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
         workflow = getToolByName(self.portal, "portal_workflow")
         workflow.setDefaultChain("simple_publication_workflow")

--- a/plone/app/event/tests/base_setup.py
+++ b/plone/app/event/tests/base_setup.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from datetime import timedelta
-from dateutil.relativedelta import relativedelta
 from plone.app.event.dx import behaviors
 from plone.app.event.testing import set_browserlayer
 from plone.app.event.testing import set_timezone
@@ -46,7 +45,7 @@ class AbstractSampleDataEvents(unittest.TestCase):
         past = self.past = tz.normalize(now - timedelta(days=10))
         future = self.future = tz.normalize(now + timedelta(days=10))
         far = self.far = tz.normalize(now + timedelta(days=30))
-        scifi = self.scifi = tz.normalize(now + relativedelta(years=50))
+        scifi = self.scifi = tz.normalize(now + 50 * timedelta(days=365))
         duration = self.duration = timedelta(hours=1)
         return (now, past, future, far, duration, scifi)
 

--- a/plone/app/event/tests/test_portlet_events.py
+++ b/plone/app/event/tests/test_portlet_events.py
@@ -2,9 +2,12 @@ from datetime import timedelta
 from plone.app.event.base import localized_now
 from plone.app.event.portlets import portlet_events
 from plone.app.event.testing import PAEvent_INTEGRATION_TESTING
+from plone.app.event.testing import PAEventDX_FUNCTIONAL_TESTING
 from plone.app.event.testing import PAEventDX_INTEGRATION_TESTING
 from plone.app.event.testing import set_env_timezone
 from plone.app.event.testing import set_timezone
+from plone.app.event.tests.base_setup import AbstractSampleDataEvents
+from plone.app.event.tests.base_setup import patched_now as PN
 from plone.app.portlets.storage import PortletAssignmentMapping
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
@@ -15,8 +18,10 @@ from plone.portlets.interfaces import IPortletDataProvider
 from plone.portlets.interfaces import IPortletManager
 from plone.portlets.interfaces import IPortletRenderer
 from plone.portlets.interfaces import IPortletType
+from plone.testing.zope import Browser
 from Products.CMFCore.utils import getToolByName
 from Products.GenericSetup.utils import _getDottedName
+from unittest import mock
 from zExceptions import Unauthorized
 from zope.component import getMultiAdapter
 from zope.component import getUtility
@@ -248,3 +253,67 @@ class RendererTest(unittest.TestCase):
         rd = r.render()
         self.assertTrue("?mode=future" in rd)
         self.assertTrue("?mode=past" in rd)
+
+
+class FunctionalTestCachedPortletEvents(AbstractSampleDataEvents):
+    layer = PAEventDX_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        from dateutil.relativedelta import relativedelta
+
+        super().setUp()
+
+        # a event in the future is needed, show in the portlet
+
+        self.scifi_event = self.event_factory(
+            container=self.portal.sub,
+            id="scifi_event",
+            title="Long Event in the future",
+            start=self.scifi,
+            location="My Home",
+        )
+        workflow = getToolByName(self.portal, "portal_workflow")
+        workflow.setDefaultChain("simple_publication_workflow")
+        workflow.doActionFor(self.scifi_event, "publish")
+        self.scifi_event.reindexObject()
+
+    def anonymous_browser(self):
+        """Browser of anonymous user"""
+        import transaction
+
+        transaction.commit()
+        browser = Browser(self.layer["app"])
+        browser.handleErrors = False
+        return browser
+
+    def test_event_portlet_links(self):
+        from io import StringIO
+        from lxml import etree
+
+        # first request, events not in ram cache
+        browser = self.anonymous_browser()
+        browser.open(f"{self.portal.absolute_url()}")
+        tree = etree.parse(StringIO(browser.contents), etree.HTMLParser())
+        result = tree.xpath("//li[contains(@class,'portletItem even')]/a/@href")
+
+        self.assertEqual(
+            result[0],
+            "http://nohost/plone/sub/scifi_event",
+            "URL of Event is wrong",
+        )
+
+        # second request, events are in ram cache
+        browser = self.anonymous_browser()
+        browser.open(f"{self.portal.absolute_url()}")
+        tree = etree.parse(StringIO(browser.contents), etree.HTMLParser())
+        result = tree.xpath("//li[contains(@class,'portletItem even')]/a/@href")
+
+        self.assertEqual(
+            result[0],
+            "http://nohost/plone/sub/scifi_event",
+            "URL of Event, calculate from ram cache, is wrong",
+        )
+
+    def tearDown(self):
+        if "scifi_event" in self.portal.sub.keys():
+            del self.portal.sub["scifi_event"]

--- a/plone/app/event/tests/test_portlet_events.py
+++ b/plone/app/event/tests/test_portlet_events.py
@@ -7,7 +7,6 @@ from plone.app.event.testing import PAEventDX_INTEGRATION_TESTING
 from plone.app.event.testing import set_env_timezone
 from plone.app.event.testing import set_timezone
 from plone.app.event.tests.base_setup import AbstractSampleDataEvents
-from plone.app.event.tests.base_setup import patched_now as PN
 from plone.app.portlets.storage import PortletAssignmentMapping
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
@@ -21,7 +20,6 @@ from plone.portlets.interfaces import IPortletType
 from plone.testing.zope import Browser
 from Products.CMFCore.utils import getToolByName
 from Products.GenericSetup.utils import _getDottedName
-from unittest import mock
 from zExceptions import Unauthorized
 from zope.component import getMultiAdapter
 from zope.component import getUtility
@@ -259,8 +257,6 @@ class FunctionalTestCachedPortletEvents(AbstractSampleDataEvents):
     layer = PAEventDX_FUNCTIONAL_TESTING
 
     def setUp(self):
-        from dateutil.relativedelta import relativedelta
-
         super().setUp()
 
         # a event in the future is needed, show in the portlet

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ setup(
             "plone.app.testing [robot]",
             "plone.testing",
             "robotsuite",
+            "lxml",
         ],
     },
 )


### PR DESCRIPTION
Eventaccessor urls are diffrent if the come from ram cache or not. in some enviroments the links are not accessible. This fix extends the url calculation.