### PR TITLE
Don't error out on 'Africa/Abidjan' timezone [gyst]

### DIFF
--- a/news/393.bugfix
+++ b/news/393.bugfix
@@ -1,0 +1,1 @@
+Don't error out on 'Africa/Abidjan' timezone [gyst]

--- a/plone/app/event/ical/exporter.py
+++ b/plone/app/event/ical/exporter.py
@@ -111,7 +111,6 @@ def add_to_zones_map(tzmap, tzid, dt):
     if tzid.lower() == "utc" or not is_datetime(dt):
         # no need to define UTC nor timezones for date objects.
         return tzmap
-    null = datetime(1, 1, 1)
     tz = pytz.timezone(tzid)
     transitions = getattr(tz, "_utc_transition_times", None)
     if not transitions:
@@ -125,7 +124,7 @@ def add_to_zones_map(tzmap, tzid, dt):
     #     datetime, which wouldn't create a match within the max-function. this
     #     way we get the maximum transition time which is smaller than the
     #     given datetime.
-    transition = max(transitions, key=lambda item: item if item <= dtzl else null)
+    transition = max(transitions, key=lambda item: item if item <= dtzl else dt.min)
 
     # get previous transition to calculate tzoffsetfrom
     idx = transitions.index(transition)
@@ -133,10 +132,10 @@ def add_to_zones_map(tzmap, tzid, dt):
     prev_transition = transitions[prev_idx]
 
     def localize(tz, dt):
-        if dt is null:
+        if dt is datetime.min:
             # dummy time, edge case
-            # (dt at beginning of all transitions, see above.)
-            return null
+            # (dt at beginning of all transitions)
+            return dt.min
         return pytz.utc.localize(dt).astimezone(tz)  # naive to utc + localize
 
     transition = localize(tz, transition)

--- a/plone/app/event/tests/test_icalendar.py
+++ b/plone/app/event/tests/test_icalendar.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from plone.app.event import base
 from plone.app.event.dx.traverser import OccurrenceTraverser as OccTravDX
+from plone.app.event.ical.exporter import add_to_zones_map
 from plone.app.event.ical.importer import ical_import
 from plone.app.event.testing import make_fake_response
 from plone.app.event.testing import PAEventDX_FUNCTIONAL_TESTING
@@ -499,3 +500,7 @@ class TestIcalImportDX(unittest.TestCase):
         self.assertNotEqual(desc21, desc22)
         self.assertTrue(start21 < start22)
         self.assertTrue(end21 < end22)
+
+    def test_add_to_zones_map(self):
+        tzmap = add_to_zones_map({}, 'Africa/Abidjan', datetime(2013, 1, 1, 0, 0))
+        self.assertTrue('Africa/Abidjan' in tzmap)

--- a/plone/app/event/tests/test_icalendar.py
+++ b/plone/app/event/tests/test_icalendar.py
@@ -502,5 +502,5 @@ class TestIcalImportDX(unittest.TestCase):
         self.assertTrue(end21 < end22)
 
     def test_add_to_zones_map(self):
-        tzmap = add_to_zones_map({}, 'Africa/Abidjan', datetime(2013, 1, 1, 0, 0))
-        self.assertTrue('Africa/Abidjan' in tzmap)
+        tzmap = add_to_zones_map({}, "Africa/Abidjan", datetime(2013, 1, 1, 0, 0))
+        self.assertTrue("Africa/Abidjan" in tzmap)


### PR DESCRIPTION
Fixes #393 by not using our own `null` datetime, which was equal but not identical to `datetime.min`.

The test provided throws an OverflowError without the patch provided.