### PR TITLE
Add old Plone 5 classes to the portlet template

### DIFF
--- a/news/416.bugfix
+++ b/news/416.bugfix
@@ -1,0 +1,9 @@
+Add old Plone 5 classes to the portlet template
+
+Add Plone 5 classes portletHeader and portletContent to the portlet template to
+improve compatibility with Plone 5 styles.
+This can help when migrating styles from Plone 5 to Plone 6.
+
+Note: This targets only portlets yet. There is probably much more to do to
+improve the Plone 5 to 6 upgrade experience.
+[thet]

--- a/plone/app/event/portlets/portlet_calendar.pt
+++ b/plone/app/event/portlets/portlet_calendar.pt
@@ -13,7 +13,7 @@
        "
   >
 
-    <div class="card-header text-center">
+    <div class="card-header portletHeader text-center">
       <a class="calendarPrevious pat-contentloader"
          href="#"
          rel="nofollow"
@@ -64,7 +64,7 @@
       >&raquo;</a>
     </div>
 
-    <div class="card-body table-responsive">
+    <div class="card-body portletContent table-responsive">
       <table class="table table-sm table-borderless mb-0"
              summary="Calendar"
              i18n:attributes="summary summary_calendar"


### PR DESCRIPTION
Add Plone 5 classes portletHeader and portletContent to the portlet template to improve compatibility with Plone 5 styles.
This can help when migrating styles from Plone 5 to Plone 6.

Note: This targets only portlets yet. There is probably much more to do to improve the Plone 5 to 6 upgrade experience.