### PR TITLE
Support icalendar 6 by forcing it to use pytz

### DIFF
--- a/news/6.bugfix
+++ b/news/6.bugfix
@@ -1,0 +1,5 @@
+Support ``icalendar`` 6 by forcing it to use its ``pytz`` timezone implementation.
+The new ``zoneinfo`` support in ``icalendar`` 6 does not work for us yet, giving indexing problems.
+So we call ``icalendar.use_pytz`` at startup.
+If this fails, we must be using an older version where ``pytz`` is the only option anyway, so we ignore this.
+[maurits]

--- a/plone/app/event/__init__.py
+++ b/plone/app/event/__init__.py
@@ -1,9 +1,26 @@
 from AccessControl.Permission import addPermission
 from zope.i18nmessageid import MessageFactory
 
+import icalendar
+import logging
 
+
+logger = logging.getLogger(__name__)
 packageName = __name__
 _ = MessageFactory("plone")
+
+# We are not yet ready to use the standard zoneinfo implementation
+# introduced in icalendar 6.  For starters, the tests fail when
+# Products.DateRecurringIndex.index.index_object is called:
+# SystemError: <class 'BTrees.IIBTree.IISet'> returned a result with an exception set
+try:
+    icalendar.use_pytz()
+    logger.info("icalendar has been set up to use pytz instead of zoneinfo.")
+except AttributeError:
+    # If use_pytz does not exist, we either have an older icalender version
+    # that only supports pytz anyway, or we have a newer version that no
+    # longer supports it at all.
+    pass
 
 # BBB Permissions
 PORTAL_ADD_PERMISSION = "Add portal events"  # CMFCalendar/ATCT permissions


### PR DESCRIPTION
The new `zoneinfo` support in `icalendar` 6 does not work for us yet, giving indexing problems. So we call `icalendar.use_pytz` at startup.
If this fails, we must be using an older version where `pytz` is the only option anyway, so we ignore this.

Locally, when I add calendar 6 in the Plone coredev 6.1 buildout, and run `bin/test -s plone.app.event -m test_icalendar` on this branch, those tests pass.

But let's first test if this is still fine in combination with icalendar 5.