### PR TITLE
Fix import problem for plone_displayview by explicitly depending on plone.app.content menu.

### DIFF
--- a/news/+fix-plone-displayviews.bugfix.rst
+++ b/news/+fix-plone-displayviews.bugfix.rst
@@ -1,0 +1,2 @@
+Fix import problem for plone_displayview by explicitly depending on plone.app.contentmenu.
+[thet]

--- a/plone/app/event/browser/configure.zcml
+++ b/plone/app/event/browser/configure.zcml
@@ -13,6 +13,7 @@
       />
 
   <!-- Event listing -->
+  <include package="plone.app.contentmenu" />
   <browser:page
       name="event_listing"
       for="plone.event.interfaces.IEvent"

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         "Products.DateRecurringIndex",
         "Products.ZCatalog",
         "Products.GenericSetup",
+        "plone.app.contentmenu",
         "plone.app.contenttypes",
         "plone.app.uuid",
         "plone.resource",


### PR DESCRIPTION
Fix a problem where plone_displayviews could not be imported in a Plone 6.1, Python 3.12 project.

I love to make my live complicated and did depend directly on Products.CMFPlone, not Plone. That might be part of the problem. However, this PR fixes it.

I found the solution via the 12 year old bug report here: https://github.com/collective/collective.blog.view/issues/5 :heart: 

OK, as I just found out it can also be fixed by really depending on CMFPlone.
I forgot to add a

```
<include package="Products.CMFPlone" />
```

Anyways, explicit is better than implicit - I think this PR makes still sense as long as plone.app.events needs plone_displayviews.

Traceback:

```
    File "/.../sources/plone.app.event/plone/app/event/browser/configure.zcml", line 16.2-25.8
    zope.schema._bootstrapinterfaces.ValidationError: ImportError: Couldn't import plone_displayviews, No module named 'plone_displayviews'
```