### PR TITLE
Stabilize tests

### DIFF
--- a/news/+stabilize-tests.internal.rst
+++ b/news/+stabilize-tests.internal.rst
@@ -1,0 +1,5 @@
+Stabilize tests.
+
+At the end of a month the calendar test was failing due to some dates reaching
+into the next month and not being rendered anymore in the current month.
+This is now stabilized.

--- a/news/+stabilize-tests.internal.rst
+++ b/news/+stabilize-tests.internal.rst
@@ -2,4 +2,4 @@ Stabilize tests.
 
 At the end of a month the calendar test was failing due to some dates reaching
 into the next month and not being rendered anymore in the current month.
-This is now stabilized.
+This is now stabilized. [thet]

--- a/plone/app/event/tests/test_portlet_calendar.py
+++ b/plone/app/event/tests/test_portlet_calendar.py
@@ -19,8 +19,6 @@ from Products.CMFCore.utils import getToolByName
 from Products.GenericSetup.utils import _getDottedName
 from zope.component import getMultiAdapter
 from zope.component import getUtility
-from zope.component.hooks import setHooks
-from zope.component.hooks import setSite
 
 import pytz
 import unittest
@@ -38,8 +36,6 @@ class PortletTest(unittest.TestCase):
         self.portal = portal
         self.request = self.layer["request"]
         setRoles(portal, TEST_USER_ID, ["Manager"])
-        setHooks()
-        setSite(portal)
 
     def testPortletTypeRegistered(self):
         portlet = getUtility(IPortletType, name="portlets.Calendar")
@@ -100,8 +96,6 @@ class RendererTest(unittest.TestCase):
         self.wft = getToolByName(self.portal, "portal_workflow")
         self.wft.setDefaultChain("simple_publication_workflow")
         setRoles(portal, TEST_USER_ID, ["Manager"])
-        setHooks()
-        setSite(portal)
 
         set_env_timezone(TZNAME)
         set_timezone(TZNAME)

--- a/plone/app/event/tests/test_portlet_calendar.py
+++ b/plone/app/event/tests/test_portlet_calendar.py
@@ -275,7 +275,12 @@ class RendererTest(unittest.TestCase):
         are used to build the calendar
         """
         tz = pytz.timezone(TZNAME)
+
         start = tz.localize(datetime.now())
+        # Set roughly in the mid of the month to avoid issues when testing at
+        # the end of a month where the tomorrow dates are already out of the
+        # range of the current calendar month.
+        start = start.replace(day=15)
         end = start + timedelta(hours=1)
 
         createContentInContainer(self.portal, PTYPE, title="e1", start=start, end=end)
@@ -348,8 +353,14 @@ class RendererTest(unittest.TestCase):
                 },
                 {
                     "i": "end",
-                    "o": "plone.app.querystring.operation.date.afterToday",
-                    "v": "",
+                    # Normally you wouldn't restrict the dates in a calendar to
+                    # allow browsing historical dates too.
+                    # And if, you'd probably want to show future events with
+                    # "end after today". But here we want reproducible results
+                    # and not hit by end-of-month boundary effects, where
+                    # tomorrow is already in another month.
+                    "o": "plone.app.querystring.operation.date.largerThan",
+                    "v": start.date().isoformat(),
                 },
                 {
                     "i": "review_state",

--- a/plone/app/event/tests/test_portlet_calendar.py
+++ b/plone/app/event/tests/test_portlet_calendar.py
@@ -275,16 +275,31 @@ class RendererTest(unittest.TestCase):
         # the end of a month where the tomorrow dates are already out of the
         # range of the current calendar month.
         start = start.replace(day=15)
+
         end = start + timedelta(hours=1)
+        start_yesterday = start - timedelta(days=1)
+        end_yesterday = start_yesterday + timedelta(hours=1)
+        start_tomorrow = start + timedelta(days=1)
+        end_tomorrow = end + timedelta(days=1)
+        end_tomorrow_1 = end_tomorrow + timedelta(days=1)
 
-        createContentInContainer(self.portal, PTYPE, title="e1", start=start, end=end)
-
-        createContentInContainer(self.portal, PTYPE, title="e2", start=start, end=end)
-
-        # starts yesterday, ends yesterday
-        start_yesterday = tz.localize(datetime.now() - timedelta(days=1))
-        end_yesterday = start + timedelta(hours=1)
-
+        # Starts today, ends today
+        createContentInContainer(
+            self.portal,
+            PTYPE,
+            title="e1",
+            start=start,
+            end=end,
+        )
+        # 2nd starts today, ends today
+        createContentInContainer(
+            self.portal,
+            PTYPE,
+            title="e2",
+            start=start,
+            end=end,
+        )
+        # Starts yesterday, ends yesterday
         createContentInContainer(
             self.portal,
             PTYPE,
@@ -292,23 +307,15 @@ class RendererTest(unittest.TestCase):
             start=start_yesterday,
             end=end_yesterday,
         )
-
-        # starts today, ends tomorrow
-        start_today = tz.localize(datetime.now())
-        end_tomorrow = start + timedelta(days=1)
-
+        # Starts today, ends tomorrow
         createContentInContainer(
             self.portal,
             PTYPE,
             title="e4",
-            start=start_today,
+            start=start,
             end=end_tomorrow,
         )
-
         # starts yesterday, ends tomorrow
-        start_yesterday = tz.localize(datetime.now() - timedelta(days=1))
-        end_tomorrow = tz.localize(datetime.now()) + timedelta(days=1)
-
         createContentInContainer(
             self.portal,
             PTYPE,
@@ -316,11 +323,7 @@ class RendererTest(unittest.TestCase):
             start=start_yesterday,
             end=end_tomorrow,
         )
-
         # starts tomorrow, ends tomorrow + 1
-        start_tomorrow = tz.localize(datetime.now() + timedelta(days=1))
-        end_tomorrow_1 = start_tomorrow + timedelta(days=1)
-
         createContentInContainer(
             self.portal,
             PTYPE,

--- a/plone/app/event/tests/test_portlet_calendar.py
+++ b/plone/app/event/tests/test_portlet_calendar.py
@@ -271,9 +271,11 @@ class RendererTest(unittest.TestCase):
         tz = pytz.timezone(TZNAME)
 
         start = tz.localize(datetime.now())
-        # Set roughly in the mid of the month to avoid issues when testing at
-        # the end of a month where the tomorrow dates are already out of the
-        # range of the current calendar month.
+        # Testing at the start or end of the month is prone to a month
+        # rollover condition, which will cause a test failure. This is not
+        # a bug in plone.app.event, but merely a test condition failure.
+        # To avoid this issue, set the start date to roughly in the middle
+        # of the month.
         start = start.replace(day=15)
 
         end = start + timedelta(hours=1)

--- a/plone/app/event/tests/test_portlet_events.py
+++ b/plone/app/event/tests/test_portlet_events.py
@@ -23,8 +23,6 @@ from Products.GenericSetup.utils import _getDottedName
 from zExceptions import Unauthorized
 from zope.component import getMultiAdapter
 from zope.component import getUtility
-from zope.component.hooks import setHooks
-from zope.component.hooks import setSite
 from zope.interface import alsoProvides
 
 import unittest
@@ -43,8 +41,6 @@ class PortletTest(unittest.TestCase):
         self.request = self.layer["request"]
         alsoProvides(self.request, IPloneFormLayer)
         setRoles(portal, TEST_USER_ID, ["Manager"])
-        setHooks()
-        setSite(portal)
 
     def testPortletTypeRegistered(self):
         portlet = getUtility(IPortletType, name="portlets.Events")


### PR DESCRIPTION
At the end of a month the calendar test was failing due to some dates reaching
into the next month and not being rendered anymore in the current month.
This is now stabilized.

![image](https://github.com/user-attachments/assets/7f6325ff-0d8f-433c-aabe-3c15e23940a0)
