### PR TITLE
fix(robot): Use element-agnostic XPath for riedit selector

### DIFF
--- a/news/432.tests
+++ b/news/432.tests
@@ -1,0 +1,1 @@
+Fix robot test selector for recurrence widget to work with both ``<a>`` and ``<button>`` elements.

--- a/src/plone/app/event/tests/robot/test_event_roundtrip.robot
+++ b/src/plone/app/event/tests/robot/test_event_roundtrip.robot
@@ -80,7 +80,7 @@ an event add form
 # When
 
 I click on Recurrence Add
-    Click  //a[@name="riedit"]
+    Click  //*[@name="riedit"]
 
 I select weekly repeat
     Select Options By  //div[contains(@class,"modal-wrapper")]//select[@id="rirtemplate"]    value    weekly


### PR DESCRIPTION
## Summary

- The recurrence widget's "Add rules" button was changed from `<a name="riedit">` to `<button type="button" name="riedit">` in plone/mockup#1533 for keyboard accessibility.
- The robot test used `//a[@name="riedit"]` which no longer matches.
- Changed to `//*[@name="riedit"]` so it works with both old `<a>` and new `<button>` elements.

Fixes the broken robot test reported in [plone/mockup#1533 (comment)](https://github.com/plone/mockup/pull/1533#issuecomment-4040783616).

## Test plan
- [ ] Robot test `test_event_roundtrip.robot` passes against current mockup