### PR TITLE
Update configuration via plone/meta 2.x

### DIFF
--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -19,7 +19,7 @@ jobs:
         - ["ubuntu", "ubuntu-latest"]
         config:
         # [Python version, visual name, tox env]
-        - ["3.13", "6.2 on py3.13", "py313-plone62"]
+        - ["3.14", "6.2 on py3.14", "py314-plone62"]
         - ["3.10", "6.2 on py3.10", "py310-plone62"]
 
     runs-on: ${{ matrix.os[1] }}

--- a/.meta.toml
+++ b/.meta.toml
@@ -3,7 +3,7 @@
 # See the inline comments on how to expand/tweak this configuration file
 [meta]
 template = "default"
-commit-id = "2.2.3.dev0"
+commit-id = "2.5.1"
 
 [tox]
 test_matrix = {"6.2" = ["*"]}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,13 +10,13 @@ repos:
     rev: v3.21.2
     hooks:
     -   id: pyupgrade
-        args: [--py38-plus]
+        args: [--py310-plus]
 -   repo: https://github.com/pycqa/isort
-    rev: 7.0.0
+    rev: 8.0.1
     hooks:
     -   id: isort
 -   repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 25.12.0
+    rev: 26.1.0
     hooks:
     -   id: black
 -   repo: https://github.com/collective/zpretty

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,5 +16,4 @@ language = "en"
 
 from pkg_resources import get_distribution  # noqa: E402
 
-
 version = release = get_distribution(project).version

--- a/news/+meta.internal
+++ b/news/+meta.internal
@@ -1,0 +1,2 @@
+Update configuration files.
+[plone devs]

--- a/news/432.tests
+++ b/news/432.tests
@@ -1,0 +1,1 @@
+Fix robot test selector for recurrence widget to work with both ``<a>`` and ``<button>`` elements.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # https://github.com/plone/meta/tree/main/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [build-system]
-requires = ["setuptools>=68.2,<80", "wheel"]
+requires = ["setuptools>=68.2,<83", "wheel"]
 
 [tool.towncrier]
 directory = "news/"
@@ -60,7 +60,7 @@ profile = "plone"
 ##
 
 [tool.black]
-target-version = ["py38"]
+target-version = ["py310"]
 
 ##
 # Add extra configuration options in .meta.toml:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from setuptools import setup
 
-
 version = "6.0.0a2.dev0"
 
 

--- a/src/plone/app/event/__init__.py
+++ b/src/plone/app/event/__init__.py
@@ -4,7 +4,6 @@ from zope.i18nmessageid import MessageFactory
 import icalendar
 import logging
 
-
 logger = logging.getLogger(__name__)
 packageName = __name__
 _ = MessageFactory("plone")

--- a/src/plone/app/event/base.py
+++ b/src/plone/app/event/base.py
@@ -34,7 +34,6 @@ from zope.deprecation import deprecate
 
 import pytz
 
-
 DEFAULT_END_DELTA = 1  # hours
 FALLBACK_TIMEZONE = "UTC"
 

--- a/src/plone/app/event/dx/behaviors.py
+++ b/src/plone/app/event/dx/behaviors.py
@@ -36,7 +36,6 @@ from zope.interface import invariant
 from zope.interface import provider
 from zope.schema.interfaces import IContextAwareDefaultFactory
 
-
 try:
     # Import fails for Plone < 6.1
     # version pin of plone.app.z3cform is set to plone.app.z3cform==4.3.2

--- a/src/plone/app/event/ical/exporter.py
+++ b/src/plone/app/event/ical/exporter.py
@@ -20,7 +20,6 @@ from zope.publisher.browser import BrowserView
 import icalendar
 import pytz
 
-
 PRODID = "-//Plone.org//NONSGML plone.app.event//EN"
 VERSION = "2.0"
 

--- a/src/plone/app/event/interfaces.py
+++ b/src/plone/app/event/interfaces.py
@@ -1,7 +1,6 @@
 from zope.interface import Interface
 from zope.publisher.interfaces.browser import IDefaultBrowserLayer
 
-
 ISO_DATE_FORMAT = "%Y-%m-%d"
 
 

--- a/src/plone/app/event/portlets/portlet_calendar.py
+++ b/src/plone/app/event/portlets/portlet_calendar.py
@@ -30,7 +30,6 @@ from zope.interface import implementer
 import calendar
 import json
 
-
 search_base_uid_source = CatalogSource(
     object_provides={
         "query": [ISyndicatableCollection.__identifier__, IFolder.__identifier__],

--- a/src/plone/app/event/setuphandlers.py
+++ b/src/plone/app/event/setuphandlers.py
@@ -5,7 +5,6 @@ from zope.interface import implementer
 
 import logging
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/plone/app/event/tests/base_setup.py
+++ b/src/plone/app/event/tests/base_setup.py
@@ -12,7 +12,6 @@ from Products.CMFCore.utils import getToolByName
 import pytz
 import unittest
 
-
 TEST_TIMEZONE = "Europe/Vienna"
 
 

--- a/src/plone/app/event/tests/robot/test_event_roundtrip.robot
+++ b/src/plone/app/event/tests/robot/test_event_roundtrip.robot
@@ -80,7 +80,7 @@ an event add form
 # When
 
 I click on Recurrence Add
-    Click  //a[@name="riedit"]
+    Click  //*[@name="riedit"]
 
 I select weekly repeat
     Select Options By  //div[contains(@class,"modal-wrapper")]//select[@id="rirtemplate"]    value    weekly

--- a/src/plone/app/event/tests/robot/variables.py
+++ b/src/plone/app/event/tests/robot/variables.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from datetime import timedelta
 
-
 # important for MONTHNAME
 NOW = datetime.now() + timedelta(days=1)
 EVENT_START_ISO = NOW.strftime("%Y-%m-%dT%H:00")

--- a/src/plone/app/event/tests/test_dx_behaviors.py
+++ b/src/plone/app/event/tests/test_dx_behaviors.py
@@ -38,7 +38,6 @@ import pytz
 import unittest
 import zope.interface
 
-
 TEST_TIMEZONE = "Europe/Vienna"
 
 

--- a/src/plone/app/event/tests/test_icalendar.py
+++ b/src/plone/app/event/tests/test_icalendar.py
@@ -16,7 +16,6 @@ import os
 import pytz
 import unittest
 
-
 # TODO:
 # * test all event properties
 # * enforce correct order: EXDATE and RDATE directly after RRULE

--- a/src/plone/app/event/tests/test_portlet_calendar.py
+++ b/src/plone/app/event/tests/test_portlet_calendar.py
@@ -23,7 +23,6 @@ from zope.component import getUtility
 import pytz
 import unittest
 
-
 TZNAME = "Europe/Vienna"
 PTYPE = "plone.app.event.dx.event"
 

--- a/src/plone/app/event/tests/test_portlet_events.py
+++ b/src/plone/app/event/tests/test_portlet_events.py
@@ -27,7 +27,6 @@ from zope.interface import alsoProvides
 
 import unittest
 
-
 TZNAME = "Australia/Brisbane"
 PTYPE = "plone.app.event.dx.event"
 

--- a/src/plone/app/event/tests/test_recurrence.py
+++ b/src/plone/app/event/tests/test_recurrence.py
@@ -35,7 +35,6 @@ import transaction
 import unittest
 import zope.component
 
-
 TZNAME = "Europe/Vienna"
 
 

--- a/src/plone/app/event/upgrades/upgrades.py
+++ b/src/plone/app/event/upgrades/upgrades.py
@@ -13,7 +13,6 @@ from zope.lifecycleevent import ObjectModifiedEvent
 
 import logging
 
-
 log = logging.getLogger(__name__)
 
 BEHAVIOR_LIST = [

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ min_version = 4.4.0
 envlist =
     lint
     test
+    py314-plone62
     py313-plone62
     py312-plone62
     py311-plone62
@@ -18,6 +19,7 @@ envlist =
 # Add extra configuration options in .meta.toml:
 # - to specify a custom testing combination of Plone and python versions, use `test_matrix`
 #   Use ["*"] to use all supported Python versions for this Plone version.
+# - to disable the test matrix entirely, set `use_test_matrix = false`
 # - to specify extra custom environments, use `envlist_lines`
 # - to specify extra `tox` top-level options, use `config_lines`
 #  [tox]
@@ -62,6 +64,7 @@ description = check if the package defines all its dependencies
 skip_install = true
 deps =
     build
+    setuptools<82.0.0
     z3c.dependencychecker==2.14.3
 commands =
     python -m build --sdist
@@ -132,6 +135,7 @@ extras =
 ##
 # Add extra configuration options in .meta.toml:
 #  [tox]
+#  skip_test_extra = true
 #  test_extras = """
 #      tests
 #      widgets


### PR DESCRIPTION
## Summary

- Adds `setuptools<82.0.0` to `[testenv:dependencies]` tox env, fixing `ModuleNotFoundError: No module named 'pkg_resources'` in the dependencies CI job
- Updates isort to 8.0.1, black to 26.1.0, pyupgrade to `--py310-plus`
- Bumps setuptools build requirement to `<83`
- Adds py3.14 to test matrix

Generated by running `config-package` against [plone/meta@2.x](https://github.com/plone/meta/tree/2.x).