### PR TITLE
Config with default template 5.x (Plone 6.0/6.1)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 #
 # EditorConfig Configuration file, for more details see:

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [flake8]
 doctests = 1

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 version: 2
 updates:

--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -1,16 +1,10 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 name: Meta
+
 on:
   push:
-    branches:
-      - master
-      - main
-  pull_request:
-    branches:
-      - master
-      - main
   workflow_dispatch:
 
 ##

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -1,10 +1,11 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 name: Tests
 
 on:
   push:
+  workflow_dispatch:
 
 jobs:
   build:
@@ -19,8 +20,6 @@ jobs:
         - ["ubuntu", "ubuntu-latest"]
         config:
         # [Python version, visual name, tox env]
-        - ["3.13", "6.2 on py3.13", "py313-plone62"]
-        - ["3.10", "6.2 on py3.10", "py310-plone62"]
         - ["3.13", "6.1 on py3.13", "py313-plone61"]
         - ["3.10", "6.1 on py3.10", "py310-plone61"]
         - ["3.9", "6.0 on py3.9", "py39-plone60"]
@@ -30,30 +29,39 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: ${{ matrix.config[1] }}
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         persist-credentials: false
-    - name: Set up Python
-      uses: actions/setup-python@v6
+    - name: Install uv + caching
+      uses: astral-sh/setup-uv@v8.2.0
       with:
+        enable-cache: true
+        cache-dependency-glob: |
+          setup.*
+          tox.ini
+          pyproject.toml
         python-version: ${{ matrix.config[0] }}
-        allow-prereleases: true
-    - name: Pip cache
-      uses: actions/cache@v4
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ matrix.config[0] }}-${{ hashFiles('setup.*', 'tox.ini') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-${{ matrix.config[0] }}-
-          ${{ runner.os }}-pip-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install tox
+
+##
+# Add extra configuration options in .meta.toml:
+#  [github]
+#  extra_lines_after_os_dependencies = """
+#  _your own configuration lines_
+#  """
+##
     - name: Initialize tox
       # the bash one-liner below does not work on Windows
       if: contains(matrix.os, 'ubuntu')
       run: |
-        if [ `tox list --no-desc -f init|wc -l` = 1 ]; then tox -e init;else true; fi
+        if [ `uvx tox list --no-desc -f init|wc -l` = 1 ]; then uvx --with tox-uv tox -e init;else true; fi
     - name: Test
-      run: tox -e ${{ matrix.config[2] }}
+      run: uvx --with tox-uv tox -e ${{ matrix.config[2] }}
+
+
+##
+# Add extra configuration options in .meta.toml:
+#  [github]
+#  extra_lines = """
+#  _your own configuration lines_
+#  """
+##

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 # python related
 *.egg-info

--- a/.meta.toml
+++ b/.meta.toml
@@ -1,16 +1,25 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [meta]
 template = "default"
-commit-id = "2.0.1.dev0"
+commit-id = "2.9.1.dev0"
 
 [pyproject]
-dependencies_ignores = "['plone.app.layout', 'Products.DateRecurringIndex']"
+dependencies_ignores = "['plone.app.layout', 'Products.DateRecurringIndex', 'setuptools']"
 codespell_ignores = "discreet,assertin,thet"
 
 [flake8]
 extra_lines = """
 per-file-ignores =
-    plone/app/event/ical/__init__.py:F401
+    src/plone/app/event/ical/__init__.py:F401
+"""
+
+[tox]
+test_matrix = {"6.1" = ["*"], "6.0" = ["*"]}
+envlist_lines = """
+# Add envs to prevent python-check-versions to complain,
+# which would force us to set requires_python to 3.9+,
+# which I don't want to do in a bugfix release.
+    py38-plone60
 """

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 ci:
     autofix_prs: false
@@ -7,20 +7,20 @@ ci:
 
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.20.0
+    rev: v3.21.2
     hooks:
     -   id: pyupgrade
-        args: [--py38-plus]
+        args: [--py39-plus]
 -   repo: https://github.com/pycqa/isort
-    rev: 6.0.1
+    rev: 9.0.0a3
     hooks:
     -   id: isort
--   repo: https://github.com/psf/black
-    rev: 25.1.0
+-   repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 26.5.1
     hooks:
     -   id: black
 -   repo: https://github.com/collective/zpretty
-    rev: 3.1.1
+    rev: 4.0.0
     hooks:
     -   id: zpretty
 
@@ -44,7 +44,7 @@ repos:
 #  """
 ##
 -   repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
     -   id: codespell
         additional_dependencies:
@@ -58,20 +58,20 @@ repos:
 #  """
 ##
 -   repo: https://github.com/mgedmin/check-manifest
-    rev: "0.50"
+    rev: "0.51"
     hooks:
     -   id: check-manifest
 -   repo: https://github.com/regebro/pyroma
-    rev: "5.0"
+    rev: "5.0.1"
     hooks:
     -   id: pyroma
 -   repo: https://github.com/mgedmin/check-python-versions
-    rev: "0.22.1"
+    rev: "0.24.2"
     hooks:
     -   id: check-python-versions
-        args: ['--only', 'setup.py,pyproject.toml']
+        args: ['--only', 'setup.py,tox.ini']
 -   repo: https://github.com/collective/i18ndude
-    rev: "6.2.1"
+    rev: "6.3.0"
     hooks:
     -   id: i18ndude
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1653,7 +1653,7 @@ Please note, the next release will have all deprections removed.
   present and thus support image fields on plone.app.event based types.
   [thet]
 
-- Change the AT validation code to an subsciption adapter. This allows reliable
+- Change the AT validation code to an subscription adapter. This allows reliable
   validation for types derived from ATEvent, which wasn't the case with the
   post_validate method.
   [thet]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,5 +16,4 @@ language = "en"
 
 from pkg_resources import get_distribution  # noqa: E402
 
-
 version = release = get_distribution(project).version

--- a/news/+meta.internal
+++ b/news/+meta.internal
@@ -1,0 +1,2 @@
+Update configuration files.
+[plone devs]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,10 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [build-system]
-requires = ["setuptools>=68.2,<80", "wheel"]
+requires = ["setuptools>=68.2,<82", "wheel"]
+
+
 
 [tool.towncrier]
 directory = "news/"
@@ -60,7 +62,7 @@ profile = "plone"
 ##
 
 [tool.black]
-target-version = ["py38"]
+target-version = ["py39"]
 
 ##
 # Add extra configuration options in .meta.toml:
@@ -120,7 +122,7 @@ Zope = [
 ]
 python-dateutil = ['dateutil']
 pytest-plone = ['pytest', 'zope.pytestlayer', 'plone.testing', 'plone.app.testing']
-ignore-packages = ['plone.app.layout', 'Products.DateRecurringIndex']
+ignore-packages = ['plone.app.layout', 'Products.DateRecurringIndex', 'setuptools']
 
 ##
 # Add extra configuration options in .meta.toml:

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,8 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
     keywords="plone event",
     author="Plone Foundation",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@ from pathlib import Path
 from setuptools import find_packages
 from setuptools import setup
 
-
 version = "5.2.5.dev0"
 
 

--- a/src/plone/app/event/__init__.py
+++ b/src/plone/app/event/__init__.py
@@ -4,7 +4,6 @@ from zope.i18nmessageid import MessageFactory
 import icalendar
 import logging
 
-
 logger = logging.getLogger(__name__)
 packageName = __name__
 _ = MessageFactory("plone")

--- a/src/plone/app/event/base.py
+++ b/src/plone/app/event/base.py
@@ -38,7 +38,6 @@ from zope.interface import Invalid
 
 import pytz
 
-
 DEFAULT_END_DELTA = 1  # hours
 FALLBACK_TIMEZONE = "UTC"
 

--- a/src/plone/app/event/dx/behaviors.py
+++ b/src/plone/app/event/dx/behaviors.py
@@ -37,7 +37,6 @@ from zope.interface import invariant
 from zope.interface import provider
 from zope.schema.interfaces import IContextAwareDefaultFactory
 
-
 try:
     # Import fails for Plone < 6.1
     # version pin of plone.app.z3cform is set to plone.app.z3cform==4.3.2

--- a/src/plone/app/event/ical/exporter.py
+++ b/src/plone/app/event/ical/exporter.py
@@ -20,7 +20,6 @@ from zope.publisher.browser import BrowserView
 import icalendar
 import pytz
 
-
 PRODID = "-//Plone.org//NONSGML plone.app.event//EN"
 VERSION = "2.0"
 

--- a/src/plone/app/event/ical/importer.py
+++ b/src/plone/app/event/ical/importer.py
@@ -39,7 +39,6 @@ import random
 import requests
 import transaction
 
-
 logger = logging.getLogger(__name__)
 # Try downloading at most this amount of bytes:
 MAXIMUM_ICAL_IMPORT_SIZE_BYTES = int(

--- a/src/plone/app/event/interfaces.py
+++ b/src/plone/app/event/interfaces.py
@@ -1,7 +1,6 @@
 from zope.interface import Interface
 from zope.publisher.interfaces.browser import IDefaultBrowserLayer
 
-
 ISO_DATE_FORMAT = "%Y-%m-%d"
 
 

--- a/src/plone/app/event/portlets/portlet_calendar.py
+++ b/src/plone/app/event/portlets/portlet_calendar.py
@@ -30,7 +30,6 @@ from zope.interface import implementer
 import calendar
 import json
 
-
 search_base_uid_source = CatalogSource(
     object_provides={
         "query": [ISyndicatableCollection.__identifier__, IFolder.__identifier__],

--- a/src/plone/app/event/setuphandlers.py
+++ b/src/plone/app/event/setuphandlers.py
@@ -5,7 +5,6 @@ from zope.interface import implementer
 
 import logging
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/plone/app/event/tests/base_setup.py
+++ b/src/plone/app/event/tests/base_setup.py
@@ -12,7 +12,6 @@ from Products.CMFCore.utils import getToolByName
 import pytz
 import unittest
 
-
 TEST_TIMEZONE = "Europe/Vienna"
 
 

--- a/src/plone/app/event/tests/robot/variables.py
+++ b/src/plone/app/event/tests/robot/variables.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from datetime import timedelta
 
-
 # important for MONTHNAME
 NOW = datetime.now() + timedelta(days=1)
 EVENT_START_ISO = NOW.strftime("%Y-%m-%dT%H:00")

--- a/src/plone/app/event/tests/test_dx_behaviors.py
+++ b/src/plone/app/event/tests/test_dx_behaviors.py
@@ -38,7 +38,6 @@ import pytz
 import unittest
 import zope.interface
 
-
 TEST_TIMEZONE = "Europe/Vienna"
 
 

--- a/src/plone/app/event/tests/test_icalendar.py
+++ b/src/plone/app/event/tests/test_icalendar.py
@@ -16,7 +16,6 @@ import os
 import pytz
 import unittest
 
-
 # TODO:
 # * test all event properties
 # * enforce correct order: EXDATE and RDATE directly after RRULE

--- a/src/plone/app/event/tests/test_portlet_calendar.py
+++ b/src/plone/app/event/tests/test_portlet_calendar.py
@@ -23,7 +23,6 @@ from zope.component import getUtility
 import pytz
 import unittest
 
-
 TZNAME = "Europe/Vienna"
 PTYPE = "plone.app.event.dx.event"
 

--- a/src/plone/app/event/tests/test_portlet_events.py
+++ b/src/plone/app/event/tests/test_portlet_events.py
@@ -27,7 +27,6 @@ from zope.interface import alsoProvides
 
 import unittest
 
-
 TZNAME = "Australia/Brisbane"
 PTYPE = "plone.app.event.dx.event"
 

--- a/src/plone/app/event/tests/test_recurrence.py
+++ b/src/plone/app/event/tests/test_recurrence.py
@@ -35,7 +35,6 @@ import transaction
 import unittest
 import zope.component
 
-
 TZNAME = "Europe/Vienna"
 
 

--- a/src/plone/app/event/upgrades/upgrades.py
+++ b/src/plone/app/event/upgrades/upgrades.py
@@ -13,7 +13,6 @@ from zope.lifecycleevent import ObjectModifiedEvent
 
 import logging
 
-
 log = logging.getLogger(__name__)
 
 BEHAVIOR_LIST = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/src/plone/meta/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [tox]
 # We need 4.4.0 for constrain_package_deps.
@@ -7,10 +7,6 @@ min_version = 4.4.0
 envlist =
     lint
     test
-    py313-plone62
-    py312-plone62
-    py311-plone62
-    py310-plone62
     py313-plone61
     py312-plone61
     py311-plone61
@@ -21,15 +17,21 @@ envlist =
     py310-plone60
     py39-plone60
     dependencies
+# Add envs to prevent python-check-versions to complain,
+# which would force us to set requires_python to 3.9+,
+# which I don't want to do in a bugfix release.
+    py38-plone60
 
 
 ##
 # Add extra configuration options in .meta.toml:
 # - to specify a custom testing combination of Plone and python versions, use `test_matrix`
+#   Use ["*"] to use all supported Python versions for this Plone version.
+# - to disable the test matrix entirely, set `use_test_matrix = false`
 # - to specify extra custom environments, use `envlist_lines`
 # - to specify extra `tox` top-level options, use `config_lines`
 #  [tox]
-#  test_matrix = {"6.2" = ["3.13", "3.12"], "6.1" = ["3.10", "3.9"]}
+#  test_matrix = {"6.2" = ["3.13", "3.12"], "6.1" = ["*"]}
 #  envlist_lines = """
 #      my_other_environment
 #  """
@@ -70,9 +72,9 @@ description = check if the package defines all its dependencies
 skip_install = true
 deps =
     build
-    z3c.dependencychecker==2.14.3
+    z3c.dependencychecker==3.0
 commands =
-    python -m build --sdist
+    python -m build --wheel
     dependencychecker
 
 [testenv:dependencies-graph]
@@ -120,7 +122,6 @@ set_env =
 ##
 deps =
     {[test_runner]deps}
-    plone62: -c https://dist.plone.org/release/6.2-dev/constraints.txt
     plone61: -c https://dist.plone.org/release/6.1-dev/constraints.txt
     plone60: -c https://dist.plone.org/release/6.0-dev/constraints.txt
 
@@ -142,6 +143,7 @@ extras =
 ##
 # Add extra configuration options in .meta.toml:
 #  [tox]
+#  skip_test_extra = true
 #  test_extras = """
 #      tests
 #      widgets
@@ -162,7 +164,7 @@ constrain_package_deps = {[base]constrain_package_deps}
 set_env = {[base]set_env}
 deps =
     {[test_runner]deps}
-    -c https://dist.plone.org/release/6.2-dev/constraints.txt
+    -c https://dist.plone.org/release/6.1-dev/constraints.txt
 
 commands = {[test_runner]test}
 extras = {[base]extras}
@@ -188,7 +190,7 @@ set_env = {[base]set_env}
 deps =
     {[test_runner]deps}
     coverage
-    -c https://dist.plone.org/release/6.2-dev/constraints.txt
+    -c https://dist.plone.org/release/6.1-dev/constraints.txt
 
 commands = {[test_runner]coverage}
 extras = {[base]extras}
@@ -201,8 +203,7 @@ deps =
     twine
     build
     towncrier
-    -c https://dist.plone.org/release/6.2-dev/constraints.txt
-
+    -c https://dist.plone.org/release/6.1-dev/constraints.txt
 commands =
     # fake version to not have to install the package
     # we build the change log as news entries might break
@@ -232,8 +233,7 @@ allowlist_externals =
 deps =
     pipdeptree
     pipforester
-    -c https://dist.plone.org/release/6.2-dev/constraints.txt
-
+    -c https://dist.plone.org/release/6.1-dev/constraints.txt
 commands =
     # Generate the full dependency tree
     sh -c 'pipdeptree -j > forest.json'


### PR DESCRIPTION
I thought I had updated all packages that were involved in today's security fixes, but apparently I forgot `plone.app.event` 5.x.  So it fails because it tries to [run the Plone 6.2 tests](https://github.com/plone/plone.app.event/actions/runs/28025656601).  Fixed by this PR.